### PR TITLE
Stop using Typhoeus and send arguments in body, clean up client

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,6 @@ gemspec
 gem "rake", "~> 12.0"
 gem "rspec", "~> 3.0"
 gem "pry"
-gem "typhoeus"
 gem "webmock"
 gem "gem-release"
+gem "faraday"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,12 +11,13 @@ GEM
     coderay (1.1.3)
     crack (0.4.4)
     diff-lcs (1.4.4)
-    ethon (0.12.0)
-      ffi (>= 1.3.0)
-    ffi (1.13.1)
+    faraday (1.1.0)
+      multipart-post (>= 1.2, < 3)
+      ruby2_keywords
     gem-release (2.2.0)
     hashdiff (1.0.1)
     method_source (1.0.0)
+    multipart-post (2.1.1)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -35,8 +36,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.3)
-    typhoeus (1.4.0)
-      ethon (>= 0.9.0)
+    ruby2_keywords (0.0.2)
     webmock (3.9.3)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -47,11 +47,11 @@ PLATFORMS
 
 DEPENDENCIES
   evervault!
+  faraday
   gem-release
   pry
   rake (~> 12.0)
   rspec (~> 3.0)
-  typhoeus
   webmock
 
 BUNDLED WITH

--- a/lib/evervault.rb
+++ b/lib/evervault.rb
@@ -6,24 +6,8 @@ module Evervault
   class << self
     attr_accessor :api_key
 
-    def run(cage_name, encrypted_data)
-      client.run(cage_name, encrypted_data)
-    end
-
-    def encrypt_and_run(cage_name, data)
-      client.encrypt_and_run(cage_name, data)
-    end
-
-    def encrypt(data)
-      client.encrypt(data)
-    end
-
-    def cages
-      client.cages
-    end
-
-    def cage_list
-      client.cage_list
+    def method_missing(method, *args, &block)
+      client.send(method, *args, &block)
     end
 
     private def client

--- a/lib/evervault/version.rb
+++ b/lib/evervault/version.rb
@@ -1,3 +1,3 @@
 module Evervault
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end


### PR DESCRIPTION
# Why
Typhoeus was behaving weirdly, sending the body as query strings instead of in the body. I've swapped it out for Faraday.

I've also cleaned up the client to use `method_missing` instead of manually writing each method the base client exposes, so we don't need to edit multiple places each time.
