### PR TITLE
Add support for async and versioned Cage runs to ruby SDK

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    evervault (0.1.1)
+    evervault (0.1.2)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    evervault (0.1.2)
+    evervault (0.1.3)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 Ruby SDK for [Evervault](https://evervault.com)
 ### Prerequisites
 
-To get started with the Evervault Ruby SDK, you will need to have created a team on the evervault dashboard.
+To get started with the Evervault Ruby SDK, you will need to have created a team on the Evervault dashboard.
 
 We are currently in invite-only early access. You can apply for early access [here](https://evervault.com).
 
@@ -63,7 +63,7 @@ result = evervault.encrypt_and_run(<CAGE-NAME>, { hello: 'World!' })
 
 ### Evervault.encrypt
 
-Encrypt lets you encrypt data for use in any of your evervault cages. You can use it to store encrypted data to be used in a cage at another time.
+Encrypt lets you encrypt data for use in any of your Evervault Cages. You can use it to store encrypted data to be used in a Cage at another time.
 
 ```ruby
 Evervault.encrypt(data = Hash | String)
@@ -75,20 +75,28 @@ Evervault.encrypt(data = Hash | String)
 
 ### Evervault.run
 
-Run lets you invoke your evervault cages with a given payload.
+Run lets you invoke your Evervault Cages with a given payload.
 
 ```ruby
-Evervault.run(cage_name = String, data = Hash)
+Evervault.run(cage_name = String, data = Hash[, options = Hash])
 ```
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| cageName | String | Name of the cage to be run |
-| data | Hash | Payload for the cage |
+| cageName | String | Name of the Cage to be run |
+| data | Hash | Payload for the Cage |
+| options | Hash | [Options for the Cage run](#Cage-Run-Options) |
+
+#### Cage Run Options
+
+| Option | Type | Default | Description |
+| ------ | ---- | ------- | ----------- |
+| `async` | `Boolean` | `false` | Run your Cage in async mode. Async Cage runs will be queued for processing. |
+| `version` | `Integer` | `nil` | Specify the version of your Cage to run. By default, the latest version will be run. |
 
 ### Evervault.encrypt_and_run
 
-Encrypt your data and use it as the payload to invoke the cage.
+Encrypt your data and use it as the payload to invoke the Cage.
 
 ```ruby
 Evervault.encrypt_and_run(cage_name = String, data = Hash)
@@ -96,7 +104,7 @@ Evervault.encrypt_and_run(cage_name = String, data = Hash)
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| cageName | String | Name of the cage to be run |
+| cageName | String | Name of the Cage to be run |
 | data | dict | Data to be encrypted |
 
 ### Evervault.cages
@@ -129,7 +137,7 @@ Evervault.cages
 
 ### Evervault.cage_list
 
-Return a `CageList` object, containing a list of your team's cages
+Return a `CageList` object, containing a list of your team's Cages
 
 ```ruby
 Evervault.cage_list
@@ -167,7 +175,7 @@ Evervault.cage_list
 
 #### CageList.to_hash
 
-Converts a list of cages to a hash with keys of CageName => Cage Model
+Converts a list of Cages to a hash with keys of CageName => Cage Model
 
 ```ruby
 Evervault.cage_list.to_hash
@@ -210,9 +218,9 @@ Evervault.cage_list.to_hash
 
 ### Evervault::Models::Cage.run
 
-Each Cage model exposes a `run` method, which allows you to run that particular cage.
+Each Cage model exposes a `run` method, which allows you to run that particular Cage.
 
-*Note*: this does not encrypt data before running the cage
+*Note*: this does not encrypt data before running the Cage
 ```ruby
 cage = Evervault.cage_list.cages[0]
 cage.run({'name': 'testing'})
@@ -221,7 +229,8 @@ cage.run({'name': 'testing'})
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| data | Hash | Payload for the cage |
+| data | Hash | Payload for the Cage |
+| options | Hash | [Options for the Cage run](#Cage-Run-Options) |
 
 ## Development
 

--- a/lib/evervault/client.rb
+++ b/lib/evervault/client.rb
@@ -30,8 +30,7 @@ module Evervault
     end
 
     def run(cage_name, encrypted_data, options = {})
-      headers = build_cage_run_headers(options)
-      @request.post(cage_name, encrypted_data, optional_headers: headers, cage_run: true)
+      @request.post(cage_name, encrypted_data, options: options, cage_run: true)
     end
 
     def encrypt_and_run(cage_name, data, options = {})
@@ -46,23 +45,6 @@ module Evervault
     def cage_list
       cages = @request.get("cages")
       @cage_list ||= Evervault::Models::CageList.new(cages: cages["cages"], request: @request)
-    end
-
-    private def build_cage_run_headers(options)
-      optional_headers = {}
-      if options.key?(:async)
-        if options[:async] == true
-          optional_headers[:"x-async"] = "true"
-        end
-        options.delete(:async)
-      end
-      if options.key?(:version)
-        if options[:version].is_a? Integer
-          optional_headers[:"x-version-id"] = options[:version].to_s
-        end
-        options.delete(:version)
-      end
-      optional_headers.merge(options)
     end
   end
 end

--- a/lib/evervault/client.rb
+++ b/lib/evervault/client.rb
@@ -29,13 +29,14 @@ module Evervault
       @crypto_client.encrypt(data)
     end
 
-    def run(cage_name, encrypted_data)
-      @request.post(cage_name, encrypted_data, cage_run: true)
+    def run(cage_name, encrypted_data, options = {})
+      headers = build_cage_run_headers(options)
+      @request.post(cage_name, encrypted_data, optional_headers: headers, cage_run: true)
     end
 
-    def encrypt_and_run(cage_name, data)
+    def encrypt_and_run(cage_name, data, options = {})
       encrypted_data = encrypt(data)
-      run(cage_name, encrypted_data)
+      run(cage_name, encrypted_data, options)
     end
 
     def cages
@@ -45,6 +46,23 @@ module Evervault
     def cage_list
       cages = @request.get("cages")
       @cage_list ||= Evervault::Models::CageList.new(cages: cages["cages"], request: @request)
+    end
+
+    private def build_cage_run_headers(options)
+      optional_headers = {}
+      if options.key?(:async)
+        if options[:async] == true
+          optional_headers[:"x-async"] = "true"
+        end
+        options.delete(:async)
+      end
+      if options.key?(:version)
+        if options[:version].is_a? Integer
+          optional_headers[:"x-version-id"] = options[:version].to_s
+        end
+        options.delete(:version)
+      end
+      optional_headers.merge(options)
     end
   end
 end

--- a/lib/evervault/http/request.rb
+++ b/lib/evervault/http/request.rb
@@ -64,7 +64,7 @@ module Evervault
         end
         if options.key?(:version)
           if options[:version].is_a? Integer
-            optional_headers[:"x-version-id"] = options[:version].to_s
+            optional_headers["x-version-id"] = options[:version].to_s
           end
           options.delete(:version)
         end

--- a/lib/evervault/http/request.rb
+++ b/lib/evervault/http/request.rb
@@ -25,8 +25,8 @@ module Evervault
         execute(:delete, build_url(path), params)
       end
 
-      def post(path, params, cage_run: false)
-        execute(:post, build_url(path, cage_run), params)
+      def post(path, params, optional_headers: {}, cage_run: false)
+        execute(:post, build_url(path, cage_run), params, optional_headers)
       end
 
       private def build_url(path, cage_run = false)
@@ -34,23 +34,23 @@ module Evervault
         "#{@cage_run_url}#{path}"
       end
 
-      def execute(method, url, params)
+      def execute(method, url, params, optional_headers = {})
         resp = Faraday.send(method, url) do |req|
             req.body = params.nil? || params.empty? ? nil : params.to_json
-            req.headers = build_headers
+            req.headers = build_headers(optional_headers)
         end
         return JSON.parse(resp.body) if resp.status >= 200 && resp.status <= 300
         Evervault::Errors::ErrorMap.raise_errors_on_failure(resp.status, resp.body)
       end
 
-      private def build_headers
-        {
+      private def build_headers(optional_headers = {})
+        optional_headers.merge({
           "AcceptEncoding": "gzip, deflate",
           "Accept": "application/json",
           "Content-Type": "application/json",
           "User-Agent": "evervault-ruby/#{VERSION}",
           "Api-Key": @api_key
-        }
+        })
       end
     end
   end

--- a/lib/evervault/http/request.rb
+++ b/lib/evervault/http/request.rb
@@ -57,8 +57,8 @@ module Evervault
         optional_headers = {}
         return optional_headers unless cage_run
         if options.key?(:async)
-          if options[:async] == true
-            optional_headers[:"x-async"] = "true"
+          if options[:async]
+            optional_headers["x-async"] = true
           end
           options.delete(:async)
         end

--- a/lib/evervault/http/request.rb
+++ b/lib/evervault/http/request.rb
@@ -26,8 +26,7 @@ module Evervault
       end
 
       def post(path, params, options: {}, cage_run: false)
-        optional_headers = build_cage_run_headers(options, cage_run)
-        execute(:post, build_url(path, cage_run), params, optional_headers)
+        execute(:post, build_url(path, cage_run), params, build_cage_run_headers(options, cage_run))
       end
 
       private def build_url(path, cage_run = false)

--- a/lib/evervault/http/request.rb
+++ b/lib/evervault/http/request.rb
@@ -43,7 +43,7 @@ module Evervault
         Evervault::Errors::ErrorMap.raise_errors_on_failure(resp.status, resp.body)
       end
 
-      private def build_headers(optional_headers = {})
+      private def build_headers(optional_headers)
         optional_headers.merge({
           "AcceptEncoding": "gzip, deflate",
           "Accept": "application/json",

--- a/lib/evervault/http/request.rb
+++ b/lib/evervault/http/request.rb
@@ -25,7 +25,8 @@ module Evervault
         execute(:delete, build_url(path), params)
       end
 
-      def post(path, params, optional_headers: {}, cage_run: false)
+      def post(path, params, options: {}, cage_run: false)
+        optional_headers = build_cage_run_headers(options, cage_run)
         execute(:post, build_url(path, cage_run), params, optional_headers)
       end
 
@@ -51,6 +52,24 @@ module Evervault
           "User-Agent": "evervault-ruby/#{VERSION}",
           "Api-Key": @api_key
         })
+      end
+
+      private def build_cage_run_headers(options, cage_run = false)
+        optional_headers = {}
+        return optional_headers unless cage_run
+        if options.key?(:async)
+          if options[:async] == true
+            optional_headers[:"x-async"] = "true"
+          end
+          options.delete(:async)
+        end
+        if options.key?(:version)
+          if options[:version].is_a? Integer
+            optional_headers[:"x-version-id"] = options[:version].to_s
+          end
+          options.delete(:version)
+        end
+        optional_headers.merge(options)
       end
     end
   end

--- a/lib/evervault/http/request.rb
+++ b/lib/evervault/http/request.rb
@@ -58,7 +58,7 @@ module Evervault
         return optional_headers unless cage_run
         if options.key?(:async)
           if options[:async]
-            optional_headers["x-async"] = true
+            optional_headers["x-async"] = "true"
           end
           options.delete(:async)
         end

--- a/lib/evervault/models/cage.rb
+++ b/lib/evervault/models/cage.rb
@@ -9,8 +9,8 @@ module Evervault
         @request = request
       end
 
-      def run(params)
-        @request.post(self.name, params, cage_run: true)
+      def run(params, options = {})
+        @request.post(self.name, params, options: options, cage_run: true)
       end
 
     end

--- a/lib/evervault/version.rb
+++ b/lib/evervault/version.rb
@@ -1,3 +1,3 @@
 module Evervault
-  VERSION = "0.1.2"
+  VERSION = "0.1.3"
 end

--- a/spec/evervault_spec.rb
+++ b/spec/evervault_spec.rb
@@ -81,6 +81,37 @@ RSpec.describe Evervault do
     end
   end
 
+  describe "run_with_options" do
+    before do
+      allow(Evervault::Http::Request).to receive(:new).and_return(request)
+      stub_request(:post, "https://cage.run/testing-cage").with(
+        headers: {
+          "Accept"=>"application/json",
+          "Accept-Encoding"=>"gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+          "Acceptencoding"=>"gzip, deflate",
+          "Api-Key"=>"testing",
+          "Content-Type"=>"application/json",
+          "User-Agent"=>"evervault-ruby/#{Evervault::VERSION}",
+          "x-async"=>"true"
+          },
+          body: {
+            name: "testing"
+          }.to_json
+        )
+           .to_return({ status: status, body: response.to_json })
+    end
+
+    context "success with options" do
+      let(:response) { { "result" =>{"status"=>"queued"} } }
+      let(:status) { 202 }
+
+      it "makes an async cage run request" do
+        Evervault.run("testing-cage", { name: "testing" }, { async: true })
+        assert_requested(:post, "https://cage.run/testing-cage", body: { name: "testing" }, times: 1)
+      end
+    end
+  end
+
   describe "encrypt_and_run" do
     before do 
       allow(Evervault::Http::Request).to receive(:new).and_return(request)

--- a/spec/evervault_spec.rb
+++ b/spec/evervault_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe Evervault do
     end
 
     context "success with options" do
-      let(:response) { { "result" =>{"status"=>"queued"} } }
+      let(:response) { { "result" =>{ "status" => "queued" } } }
       let(:status) { 202 }
 
       it "makes an async cage run request" do


### PR DESCRIPTION
# Why
Expose async Cage runs and versioned Cage runs through the Ruby SDK.

# How
Add optional parameter to top level `run`, `encrypt_and_run` and `Cage.run` to take `async` and `version` as options. These will then be set as headers on the Cage run.
Also added tests and updated the README