### PR TITLE
Fix Evervault logo link on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Evervault](https://evervault.com/evervault.svg)](https://welcome.evervault.com/)
+[![Evervault](https://evervault.com/evervault.svg)](https://evervault.com/)
 
 [![Unit Tests Status](https://github.com/evervault/evervault-ruby/workflows/evervault-unit-tests/badge.svg)](https://github.com/evervault/evervault-ruby/actions?query=workflow%3Aevervault-unit-tests)
 


### PR DESCRIPTION
Link was pointing to old welcome.evervault.com website.