### PR TITLE
feat(create_run_token): Allow non preapproved payloads for creating r…

### DIFF
--- a/lib/evervault/client.rb
+++ b/lib/evervault/client.rb
@@ -47,6 +47,8 @@ module Evervault
     end
 
     def create_run_token(function_name, data)
+      if not data
+        data = {}
       @request_handler.post("v2/functions/#{function_name}/run-token", data)
     end
   end

--- a/lib/evervault/client.rb
+++ b/lib/evervault/client.rb
@@ -49,6 +49,7 @@ module Evervault
     def create_run_token(function_name, data)
       if not data
         data = {}
+      end
       @request_handler.post("v2/functions/#{function_name}/run-token", data)
     end
   end

--- a/lib/evervault/client.rb
+++ b/lib/evervault/client.rb
@@ -46,10 +46,7 @@ module Evervault
       end
     end
 
-    def create_run_token(function_name, data)
-      if not data
-        data = {}
-      end
+    def create_run_token(function_name, data = {})
       @request_handler.post("v2/functions/#{function_name}/run-token", data)
     end
   end


### PR DESCRIPTION
…un tokens

# Why
Users should be able to create run tokens without providing a payload for approval.

# How
If `data` is not passed to the `create_run_token` function, then assign an empty object to `data`.