### PR TITLE
Eoin/etr 709 remove method missing from ruby sdk

### DIFF
--- a/lib/evervault.rb
+++ b/lib/evervault.rb
@@ -6,8 +6,20 @@ module Evervault
   class << self
     attr_accessor :api_key
 
-    def method_missing(method, *args, &block)
-      client.send(method, *args, &block)
+    def encrypt(data)
+      client.encrypt(data)
+    end
+
+    def run(function_name, encrypted_data, options = {})
+      client.run(function_name, encrypted_data, options)
+    end
+
+    def enable_outbound_relay(decryption_domains = nil)
+      client.enable_outbound_relay(decryption_domains)
+    end
+
+    def create_run_token(function_name, data = {})
+      client.create_run_token(function_name, data)
     end
 
     private def client

--- a/lib/evervault/version.rb
+++ b/lib/evervault/version.rb
@@ -1,4 +1,4 @@
 module Evervault
-  VERSION = "1.3.0"
+  VERSION = "1.3.1"
   EV_VERSION = {"prime256v1" => "NOC", "secp256k1" => "DUB"}
 end


### PR DESCRIPTION
# Why
`method_missing` makes the Evervault Module hard to mock in tests as all non matching calls are going to the client.

# How
- Remove `method_missing` and replace simpler interface.