### PR TITLE
Avoid the possibility of ever calling private methods

### DIFF
--- a/lib/evervault/http/request.rb
+++ b/lib/evervault/http/request.rb
@@ -12,7 +12,7 @@ module Evervault
       end
 
       def execute(method, url, params, optional_headers = {})
-        resp = Faraday.send(method, url) do |req|
+        resp = Faraday.public_send(method, url) do |req|
             req.body = params.nil? || params.empty? ? nil : params.to_json
             req.headers = build_headers(optional_headers)
             req.options.timeout = @timeout


### PR DESCRIPTION
`send()` is one of those semi-red-flag functions for hardcoded use.