### PR TITLE
Update NetHTTPOverride module to alias NetHTTP functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /pkg/
 /spec/reports/
 /tmp/
+Gemfile.lock
 
 # rspec failure tracking
 .rspec_status

--- a/lib/evervault/version.rb
+++ b/lib/evervault/version.rb
@@ -1,4 +1,4 @@
 module Evervault
-  VERSION = "1.3.1"
+  VERSION = "1.3.2"
   EV_VERSION = {"prime256v1" => "NOC", "secp256k1" => "DUB"}
 end


### PR DESCRIPTION
# Why
When our SDK is combined with libraries which also patch Net::HTTP, we end up with a stack overflow. Our override module prepends to the Net::HTTP which can trigger an infinite loop through calls to `super`. 

This was noticed and repro'd using [Isolator](https://github.com/palkan/isolator) (through its use of [Sniffer](https://github.com/aderyabin/sniffer))

# How
Update our override module to include our override module in class_eval, and alias the methods instead of prepending naively. 

Aliasing allows us to disambiguate the functions we want to call, and prevents recursion through use of super:
```ruby
alias_method :request_without_intercept, :request
alias_method :request, :request_with_intercept

...

def request_with_intercept(req, body = nil, &block)
  # Perform some intercept logic...
  request_without_intercept(req, body, &block)
end
```