### PR TITLE
feat!: Add decrypt function

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos]
-        ruby: [2.5, 2.6, 2.7, 3.1, truffleruby]
+        ruby: [2.6, 2.7, 3.1, truffleruby]
     runs-on: ${{ matrix.os }}-latest
     continue-on-error: ${{ endsWith(matrix.ruby, 'head') || matrix.ruby == 'debug' }}
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ${{ matrix.os }}-latest
     continue-on-error: ${{ endsWith(matrix.ruby, 'head') || matrix.ruby == 'debug' }}
     steps:
-    - uses: actions/checkout@v2
-    - uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ matrix.ruby }}
-    - run: bundle install
-    - run: bundle exec rake
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+      - run: bundle install
+      - run: bundle exec rake
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -7,7 +7,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos]
-        ruby: [2.5, 2.6, 2.7, 3.1, truffleruby]
+        ruby: [2.6, 2.7, 3.1, truffleruby]
     runs-on: ${{ matrix.os }}-latest
     continue-on-error: ${{ endsWith(matrix.ruby, 'head') || matrix.ruby == 'debug' }}
     steps:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ${{ matrix.os }}-latest
     continue-on-error: ${{ endsWith(matrix.ruby, 'head') || matrix.ruby == 'debug' }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{ matrix.ruby }}
+    - uses: actions/checkout@v2
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
     - run: bundle install
     - run: bundle exec rake

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ${{ matrix.os }}-latest
     continue-on-error: ${{ endsWith(matrix.ruby, 'head') || matrix.ruby == 'debug' }}
     steps:
-    - uses: actions/checkout@v2
-    - uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ matrix.ruby }}
-    - run: bundle install
-    - run: bundle exec rake
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+      - run: bundle install
+      - run: bundle exec rake

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ${{ matrix.os }}-latest
     continue-on-error: ${{ endsWith(matrix.ruby, 'head') || matrix.ruby == 'debug' }}
     steps:
-    - uses: actions/checkout@v2
-    - uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ matrix.ruby }}
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
     - run: bundle install
     - run: bundle exec rake

--- a/README.md
+++ b/README.md
@@ -49,11 +49,14 @@ To make Evervault available for use in your app:
 require "evervault"
 
 # Initialize the client with your App's ID and App's API key
-Evervault.app_uuid = <YOUR-APP-ID>
+Evervault.app_id = <YOUR-APP-ID>
 Evervault.api_key = <YOUR-API-KEY>
 
 # Encrypt your data
-encrypted_data = Evervault.encrypt({ hello: 'World!' })
+encrypted_data = Evervault.encrypt('Hello World!')
+
+# Decrypt your data
+decrypted = Evervault.decrypt(encrypted_data)
 
 # Process the encrypted data using a Function
 result = Evervault.run(<FUNCTION-NAME>, encrypted_data)
@@ -67,8 +70,6 @@ http = Net::HTTP.new(uri.host, uri.port)
 http.use_ssl = true
 res = http.request(req)
 
-# Decrypt your data
-decrypted = Evervault.decrypt({ encrypted: encrypted_data })
 ```
 
 ## Reference
@@ -83,25 +84,26 @@ The Evervault Ruby SDK exposes four methods.
 Evervault.encrypt(data = String | Number | Boolean | Hash | Array)
 ```
 
-| Parameter | Type | Description |
-| --------- | ---- | ----------- |
-| data | `String`, `Number`, `Boolean`, `Hash`, `Array` | Data to be encrypted |
+| Parameter | Type                                           | Description          |
+| --------- | ---------------------------------------------- | -------------------- |
+| data      | `String`, `Number`, `Boolean`, `Hash`, `Array` | Data to be encrypted |
 
 ### Evervault.decrypt
 
-`Evervault.decrypt` decrypts the data previously encrypted with the `Evervault.encrypt` function or through Relay.
+`Evervault.decrypt` decrypts data previously encrypted with the `encrypt()` function or through Evervault's Relay (Evervault's encryption proxy).
+An API Key with the `decrypt` permission must be used to perform this operation.
 
 ```ruby
-Evervault.decrypt(data = Hash)
+Evervault.decrypt(data = String | Array | Hash)
 ```
 
-| Parameter | Type   | Description          |
-| --------- | ------ | -------------------- |
-| data      | `Hash` | Data to be decrypted |
+| Parameter | Type                      | Description          |
+| --------- | ------------------------- | -------------------- |
+| data      | `String`, `Array`, `Hash` | Data to be decrypted |
 
 ### Evervault.enable_outbound_relay
 
-`Evervault.enable_outbound_relay` configures your application to proxy HTTP requests using Outbound Relay based on the configuration created in the Evervault UI. See [Outbound Relay](https://docs.evervault.com/concepts/outbound-relay/overview) to learn more.  
+`Evervault.enable_outbound_relay` configures your application to proxy HTTP requests using Outbound Relay based on the configuration created in the Evervault UI. See [Outbound Relay](https://docs.evervault.com/concepts/outbound-relay/overview) to learn more.
 
 ```ruby
 Evervault.enable_outbound_relay([decryption_domains = Array])
@@ -114,6 +116,7 @@ Evervault.enable_outbound_relay([decryption_domains = Array])
 ### Evervault.run
 
 `Evervault.run` invokes a Function with a given payload.
+An API Key with the `run Function` permission must be used to perform this operation.
 
 ```ruby
 Evervault.run(function_name = String, data = Hash[, options = Hash])
@@ -135,6 +138,7 @@ Evervault.run(function_name = String, data = Hash[, options = Hash])
 ### Evervault.create_run_token
 
 `Evervault.create_run_token` creates a single use, time bound token for invoking a Function.
+An API Key with the `create Run Token` permission must be used to perform this operation.
 
 ```ruby
 Evervault.create_run_token(function_name = String, data = Hash)

--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ To make Evervault available for use in your app:
 ```ruby
 require "evervault"
 
-# Initialize the client with your team's API key
-Evervault.api_key = <YOUR-API-KEY>
+# Initialize the client with your App's ID and App's API key
 Evervault.app_uuid = <YOUR-APP-ID>
+Evervault.api_key = <YOUR-API-KEY>
 
 # Encrypt your data
 encrypted_data = Evervault.encrypt({ hello: 'World!' })

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ require "evervault"
 
 # Initialize the client with your team's API key
 Evervault.api_key = <YOUR-API-KEY>
+Evervault.app_uuid = <YOUR-APP-ID>
 
 # Encrypt your data
 encrypted_data = Evervault.encrypt({ hello: 'World!' })
@@ -65,6 +66,9 @@ req.body = encrypted_data.to_json
 http = Net::HTTP.new(uri.host, uri.port)
 http.use_ssl = true
 res = http.request(req)
+
+# Decrypt your data
+decrypted = Evervault.decrypt({ encrypted: encrypted_data })
 ```
 
 ## Reference
@@ -82,6 +86,18 @@ Evervault.encrypt(data = String | Number | Boolean | Hash | Array)
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | data | `String`, `Number`, `Boolean`, `Hash`, `Array` | Data to be encrypted |
+
+### Evervault.decrypt
+
+`Evervault.decrypt` decrypts the data previously encrypted with the `Evervault.encrypt` function or through Relay.
+
+```ruby
+Evervault.decrypt(data = Hash)
+```
+
+| Parameter | Type   | Description          |
+| --------- | ------ | -------------------- |
+| data      | `Hash` | Data to be decrypted |
 
 ### Evervault.enable_outbound_relay
 

--- a/lib/evervault.rb
+++ b/lib/evervault.rb
@@ -5,6 +5,7 @@ require_relative "evervault/errors/errors"
 module Evervault
   class << self
     attr_accessor :api_key
+    attr_accessor :app_uuid
 
     def encrypt(data)
       client.encrypt(data)
@@ -28,7 +29,12 @@ module Evervault
                 "Please enter your team's API Key"
               )
       end
-      @client ||= Evervault::Client.new(api_key: api_key)
+      if app_uuid.nil?
+        raise Evervault::Errors::AuthenticationError.new(
+          "Please enter your App ID"
+        )
+      end
+      @client ||= Evervault::Client.new(api_key: api_key, app_uuid: app_uuid)
     end
   end
 end

--- a/lib/evervault.rb
+++ b/lib/evervault.rb
@@ -4,8 +4,8 @@ require_relative "evervault/errors/errors"
 
 module Evervault
   class << self
-    attr_accessor :api_key
     attr_accessor :app_uuid
+    attr_accessor :api_key
 
     def encrypt(data)
       client.encrypt(data)
@@ -28,17 +28,17 @@ module Evervault
     end
 
     private def client
-      if api_key.nil?
-        raise Evervault::Errors::AuthenticationError.new(
-                "Please enter your team's API Key"
-              )
-      end
       if app_uuid.nil?
         raise Evervault::Errors::AuthenticationError.new(
           "Please enter your App ID"
         )
       end
-      @client ||= Evervault::Client.new(api_key: api_key, app_uuid: app_uuid)
+      if api_key.nil?
+        raise Evervault::Errors::AuthenticationError.new(
+                "Please enter your team's API Key"
+              )
+      end
+      @client ||= Evervault::Client.new(app_uuid: app_uuid, api_key: api_key)
     end
   end
 end

--- a/lib/evervault.rb
+++ b/lib/evervault.rb
@@ -1,10 +1,11 @@
 require_relative "evervault/version"
 require_relative "evervault/client"
 require_relative "evervault/errors/errors"
+require_relative "evervault/utils/validation_utils"
 
 module Evervault
   class << self
-    attr_accessor :app_uuid
+    attr_accessor :app_id
     attr_accessor :api_key
 
     def encrypt(data)
@@ -28,17 +29,8 @@ module Evervault
     end
 
     private def client
-      if app_uuid.nil?
-        raise Evervault::Errors::AuthenticationError.new(
-          "Please enter your App ID"
-        )
-      end
-      if api_key.nil?
-        raise Evervault::Errors::AuthenticationError.new(
-                "Please enter your team's API Key"
-              )
-      end
-      @client ||= Evervault::Client.new(app_uuid: app_uuid, api_key: api_key)
+      Evervault::Utils::ValidationUtils.validate_app_uuid_and_api_key(app_id, api_key)
+      @client ||= Evervault::Client.new(app_uuid: app_id, api_key: api_key)
     end
   end
 end

--- a/lib/evervault.rb
+++ b/lib/evervault.rb
@@ -11,6 +11,10 @@ module Evervault
       client.encrypt(data)
     end
 
+    def decrypt(data)
+      client.decrypt(data)
+    end
+
     def run(function_name, encrypted_data, options = {})
       client.run(function_name, encrypted_data, options)
     end

--- a/lib/evervault/client.rb
+++ b/lib/evervault/client.rb
@@ -11,6 +11,7 @@ module Evervault
     attr_accessor :api_key, :base_url, :cage_run_url, :request_timeout
     def initialize(
       api_key:,
+      app_uuid:,
       base_url: "https://api.evervault.com/",
       cage_run_url: "https://run.evervault.com/",
       relay_url: "https://relay.evervault.com:8443",
@@ -18,7 +19,7 @@ module Evervault
       request_timeout: 30,
       curve: 'prime256v1'
     )
-      @request = Evervault::Http::Request.new(timeout: request_timeout, api_key: api_key)
+      @request = Evervault::Http::Request.new(timeout: request_timeout, api_key: api_key, app_uuid: app_uuid)
       @intercept = Evervault::Http::RequestIntercept.new(
         request: @request, ca_host: ca_host, api_key: api_key, base_url: base_url, relay_url: relay_url
       )
@@ -36,6 +37,14 @@ module Evervault
 
     def run(function_name, encrypted_data, options = {})
       @request_handler.post(function_name, encrypted_data, options: options, cage_run: true)
+    end
+
+    def decrypt(data)
+      raise Evervault::Errors::ArgumentError.new(
+          "data must be of type Hash"
+        ) if !(data.instance_of?(Hash))
+
+      @request_handler.post("/decrypt", data)
     end
 
     def enable_outbound_relay(decryption_domains = nil)

--- a/lib/evervault/client.rb
+++ b/lib/evervault/client.rb
@@ -44,7 +44,7 @@ module Evervault
           "data must be of type Hash"
         ) if !(data.instance_of?(Hash))
 
-      @request_handler.post("/decrypt", data)
+      @request_handler.post("decrypt", data)
     end
 
     def enable_outbound_relay(decryption_domains = nil)

--- a/lib/evervault/client.rb
+++ b/lib/evervault/client.rb
@@ -8,24 +8,25 @@ require_relative "crypto/client"
 module Evervault
   class Client
 
-    attr_accessor :api_key, :base_url, :cage_run_url, :request_timeout
+    attr_accessor :function_run_url
     def initialize(
       app_uuid:,
       api_key:,
       base_url: "https://api.evervault.com/",
-      cage_run_url: "https://run.evervault.com/",
+      function_run_url: "https://run.evervault.com/",
       relay_url: "https://relay.evervault.com:8443",
       ca_host: "https://ca.evervault.com",
       request_timeout: 30,
       curve: 'prime256v1'
     )
+      @function_run_url = function_run_url
       @request = Evervault::Http::Request.new(timeout: request_timeout, app_uuid: app_uuid, api_key: api_key)
       @intercept = Evervault::Http::RequestIntercept.new(
         request: @request, ca_host: ca_host, api_key: api_key, base_url: base_url, relay_url: relay_url
       )
       @request_handler =
         Evervault::Http::RequestHandler.new(
-          request: @request, base_url: base_url, cage_run_url: cage_run_url, cert: @intercept
+          request: @request, base_url: base_url, cert: @intercept
         )
       @crypto_client = Evervault::Crypto::Client.new(request_handler: @request_handler, curve: curve)
       @intercept.setup()
@@ -35,16 +36,32 @@ module Evervault
       @crypto_client.encrypt(data)
     end
 
-    def run(function_name, encrypted_data, options = {})
-      @request_handler.post(function_name, encrypted_data, options: options, cage_run: true)
+    def decrypt(data)
+      unless data.is_a?(String) || data.is_a?(Array) || data.is_a?(Hash)
+        raise Evervault::Errors::ArgumentError.new("data is of invalid type")
+      end
+      payload = { data: data }
+      response = @request_handler.post("decrypt", payload, nil, nil, true)
+      response["data"]
     end
 
-    def decrypt(data)
-      raise Evervault::Errors::ArgumentError.new(
-          "data must be of type Hash"
-        ) if !(data.instance_of?(Hash))
+    def run(function_name, payload, options = {})
+      optional_headers = {}
+      if options.key?(:async)
+        if options[:async]
+          optional_headers["x-async"] = "true"
+        end
+      end
+      if options.key?(:version)
+        if options[:version].is_a? Integer
+          optional_headers["x-version-id"] = options[:version].to_s
+        end
+      end
+      @request_handler.post(function_name, payload, optional_headers, @function_run_url)
+    end
 
-      @request_handler.post("decrypt", data)
+    def create_run_token(function_name, data = {})
+      @request_handler.post("v2/functions/#{function_name}/run-token", data)
     end
 
     def enable_outbound_relay(decryption_domains = nil)
@@ -53,10 +70,6 @@ module Evervault
       else
         @intercept.setup_decryption_domains(decryption_domains)
       end
-    end
-
-    def create_run_token(function_name, data = {})
-      @request_handler.post("v2/functions/#{function_name}/run-token", data)
     end
   end
 end

--- a/lib/evervault/client.rb
+++ b/lib/evervault/client.rb
@@ -10,8 +10,8 @@ module Evervault
 
     attr_accessor :api_key, :base_url, :cage_run_url, :request_timeout
     def initialize(
-      api_key:,
       app_uuid:,
+      api_key:,
       base_url: "https://api.evervault.com/",
       cage_run_url: "https://run.evervault.com/",
       relay_url: "https://relay.evervault.com:8443",
@@ -19,7 +19,7 @@ module Evervault
       request_timeout: 30,
       curve: 'prime256v1'
     )
-      @request = Evervault::Http::Request.new(timeout: request_timeout, api_key: api_key, app_uuid: app_uuid)
+      @request = Evervault::Http::Request.new(timeout: request_timeout, app_uuid: app_uuid, api_key: api_key)
       @intercept = Evervault::Http::RequestIntercept.new(
         request: @request, ca_host: ca_host, api_key: api_key, base_url: base_url, relay_url: relay_url
       )

--- a/lib/evervault/http/request.rb
+++ b/lib/evervault/http/request.rb
@@ -1,14 +1,16 @@
 require "faraday"
 require "json"
+require "base64"
 require_relative "../version"
 require_relative "../errors/error_map"
 
 module Evervault
   module Http
     class Request
-      def initialize(timeout:, api_key:)
+      def initialize(timeout:, api_key:, app_uuid:)
         @timeout = timeout
         @api_key = api_key
+        @app_uuid = app_uuid
       end
 
       def execute(method, url, params, optional_headers = {})
@@ -30,6 +32,7 @@ module Evervault
           "Content-Type": "application/json",
           "User-Agent": "evervault-ruby/#{VERSION}",
           "Api-Key": @api_key,
+          "Authorization": Base64.encode("#{@app_uuid}:#{@api_key}")
         })
       end
     end

--- a/lib/evervault/http/request.rb
+++ b/lib/evervault/http/request.rb
@@ -6,10 +6,10 @@ require_relative "../errors/error_map"
 module Evervault
   module Http
     class Request
-      def initialize(timeout:, api_key:, app_uuid:)
+      def initialize(timeout:, app_uuid:, api_key:)
         @timeout = timeout
-        @api_key = api_key
         @app_uuid = app_uuid
+        @api_key = api_key
       end
 
       def execute(method, url, params, optional_headers = {})

--- a/lib/evervault/http/request.rb
+++ b/lib/evervault/http/request.rb
@@ -13,7 +13,7 @@ module Evervault
       end
 
       def execute(method, url, params, optional_headers = {})
-        resp = faraday.public_send(method, url) do |req|
+        resp = faraday(url).public_send(method, url) do |req, url|
             req.body = params.nil? || params.empty? ? nil : params.to_json
             req.headers = build_headers(optional_headers)
             req.options.timeout = @timeout
@@ -28,9 +28,11 @@ module Evervault
 
       private
 
-      def faraday
+      def faraday(url)
         Faraday.new do |conn|
-          conn.request :authorization, :basic, @app_uuid, @api_key
+          if url.include? "/decrypt"
+            conn.request :authorization, :basic, @app_uuid, @api_key
+          end
         end
       end
 

--- a/lib/evervault/utils/validation_utils.rb
+++ b/lib/evervault/utils/validation_utils.rb
@@ -1,0 +1,31 @@
+require 'digest'
+
+module Evervault
+  module Utils
+    class ValidationUtils
+
+      def self.validate_app_uuid_and_api_key(app_uuid, api_key)
+        if app_uuid.nil?
+          raise Evervault::Errors::AuthenticationError.new(
+            "No App ID provided. The App ID can be retrieved in the Evervault dashboard (App Settings)."
+          )
+        end
+        if api_key.nil?
+          raise Evervault::Errors::AuthenticationError.new(
+            "The provided App ID is invalid. The App ID can be retrieved in the Evervault dashboard (App Settings)."
+          )
+        end
+        if api_key.start_with?('ev:key')
+          # Scoped API key
+          app_uuid_hash = Digest::SHA512.base64digest(app_uuid)[0, 6]
+          app_uuid_hash_from_api_key = api_key.split(':')[4]
+          if app_uuid_hash != app_uuid_hash_from_api_key
+            raise Evervault::Errors::AuthenticationError.new(
+              "The API key is not valid for app #{app_uuid}. Make sure to use an API key belonging to the app #{app_uuid}."
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/evervault/version.rb
+++ b/lib/evervault/version.rb
@@ -1,4 +1,4 @@
 module Evervault
-  VERSION = "1.3.2"
+  VERSION = "2.0.0"
   EV_VERSION = {"prime256v1" => "NOC", "secp256k1" => "DUB"}
 end

--- a/spec/evervault_spec.rb
+++ b/spec/evervault_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe Evervault do
   let(:request) do
     Evervault::Http::Request.new(
       timeout: 30,
-      api_key: "testing",
-      app_uuid: "app_test"
+      app_uuid: "app_test",
+      api_key: "testing"
     )
   end
   let(:intercept) do
@@ -70,8 +70,8 @@ Gu2q1tR9TzpXYZ+Yv1/YUApnryI8Dbd2azpYW4obHvGOFS1bxNQ3waqmx51ig45S
   end
 
   before :each do 
-    Evervault.api_key = "testing" 
     Evervault.app_uuid = "app_test"
+    Evervault.api_key = "testing" 
     allow(Time).to receive(:now).and_return(Time.parse('2022-06-06'))
   end
 

--- a/spec/evervault_spec.rb
+++ b/spec/evervault_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Evervault do
     Evervault::Http::Request.new(
       timeout: 30,
       api_key: "testing",
+      app_uuid: "app_test"
     )
   end
   let(:intercept) do
@@ -70,6 +71,7 @@ Gu2q1tR9TzpXYZ+Yv1/YUApnryI8Dbd2azpYW4obHvGOFS1bxNQ3waqmx51ig45S
 
   before :each do 
     Evervault.api_key = "testing" 
+    Evervault.app_uuid = "app_test"
     allow(Time).to receive(:now).and_return(Time.parse('2022-06-06'))
   end
 

--- a/spec/evervault_spec.rb
+++ b/spec/evervault_spec.rb
@@ -24,7 +24,6 @@ RSpec.describe Evervault do
     Evervault::Http::RequestHandler.new(
       request: request,
       base_url: "https://api.evervault.com/", 
-      cage_run_url: "https://cage.run/", 
       cert: intercept
     ) 
   end
@@ -70,7 +69,7 @@ Gu2q1tR9TzpXYZ+Yv1/YUApnryI8Dbd2azpYW4obHvGOFS1bxNQ3waqmx51ig45S
   end
 
   before :each do 
-    Evervault.app_uuid = "app_test"
+    Evervault.app_id = "app_test"
     Evervault.api_key = "testing" 
     allow(Time).to receive(:now).and_return(Time.parse('2022-06-06'))
   end
@@ -161,7 +160,7 @@ Gu2q1tR9TzpXYZ+Yv1/YUApnryI8Dbd2azpYW4obHvGOFS1bxNQ3waqmx51ig45S
   describe "run" do
     before do 
       allow(Evervault::Http::RequestHandler).to receive(:new).and_return(request)
-      stub_request(:post, "https://cage.run/testing-cage").with(
+      stub_request(:post, "https://run.evervault.com/testing-cage").with(
         headers: {
           "Accept"=>"application/json",
           "Accept-Encoding"=>"gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
@@ -183,7 +182,7 @@ Gu2q1tR9TzpXYZ+Yv1/YUApnryI8Dbd2azpYW4obHvGOFS1bxNQ3waqmx51ig45S
 
       it "makes a post request to the cage run API" do
         Evervault.run("testing-cage", { name: "testing" })
-        assert_requested(:post, "https://cage.run/testing-cage", body: { name: "testing" }, times: 1)
+        assert_requested(:post, "https://run.evervault.com/testing-cage", body: { name: "testing" }, times: 1)
       end
     end
 
@@ -193,7 +192,7 @@ Gu2q1tR9TzpXYZ+Yv1/YUApnryI8Dbd2azpYW4obHvGOFS1bxNQ3waqmx51ig45S
 
       it "makes a post request to the cage run API and maps the error" do
         expect { Evervault.run("testing-cage", { name: "testing" }) }.to raise_error(Evervault::Errors::BadRequestError)
-        assert_requested(:post, "https://cage.run/testing-cage", body: { name: "testing" }, times: 1)
+        assert_requested(:post, "https://run.evervault.com/testing-cage", body: { name: "testing" }, times: 1)
       end
     end
   end
@@ -201,7 +200,7 @@ Gu2q1tR9TzpXYZ+Yv1/YUApnryI8Dbd2azpYW4obHvGOFS1bxNQ3waqmx51ig45S
   describe "run_with_options" do
     before do
       allow(Evervault::Http::RequestHandler).to receive(:new).and_return(request)
-      stub_request(:post, "https://cage.run/testing-cage").with(
+      stub_request(:post, "https://run.evervault.com/testing-cage").with(
         headers: {
           "Accept"=>"application/json",
           "Accept-Encoding"=>"gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
@@ -224,7 +223,7 @@ Gu2q1tR9TzpXYZ+Yv1/YUApnryI8Dbd2azpYW4obHvGOFS1bxNQ3waqmx51ig45S
 
       it "makes an async cage run request" do
         Evervault.run("testing-cage", { name: "testing" }, { async: true })
-        assert_requested(:post, "https://cage.run/testing-cage", body: { name: "testing" }, times: 1)
+        assert_requested(:post, "https://run.evervault.com/testing-cage", body: { name: "testing" }, times: 1)
       end
     end
   end

--- a/spec/handling_cert_spec.rb
+++ b/spec/handling_cert_spec.rb
@@ -80,7 +80,7 @@ qLZdvkgx0KBRnP/JPZ55VgjZ8ipH9+SGxsZeTg9sX6nw+x/Plncz
   end
 
   before :each do 
-    Evervault.app_uuid = "app_uuid"
+    Evervault.app_id = "app_uuid"
     Evervault.api_key = "testing" 
   end
 

--- a/spec/handling_cert_spec.rb
+++ b/spec/handling_cert_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe Evervault do
   let(:request) do
     Evervault::Http::Request.new(
       timeout: 30,
-      api_key: "testing",
-      app_uuid: "app_test"
+      app_uuid: "app_test",
+      api_key: "testing"
     )
   end
   let(:intercept) do
@@ -80,8 +80,8 @@ qLZdvkgx0KBRnP/JPZ55VgjZ8ipH9+SGxsZeTg9sX6nw+x/Plncz
   end
 
   before :each do 
-    Evervault.api_key = "testing" 
     Evervault.app_uuid = "app_uuid"
+    Evervault.api_key = "testing" 
   end
 
   describe "test_cert_is_valid" do

--- a/spec/handling_cert_spec.rb
+++ b/spec/handling_cert_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Evervault do
     Evervault::Http::Request.new(
       timeout: 30,
       api_key: "testing",
+      app_uuid: "app_test"
     )
   end
   let(:intercept) do
@@ -80,6 +81,7 @@ qLZdvkgx0KBRnP/JPZ55VgjZ8ipH9+SGxsZeTg9sX6nw+x/Plncz
 
   before :each do 
     Evervault.api_key = "testing" 
+    Evervault.app_uuid = "app_uuid"
   end
 
   describe "test_cert_is_valid" do

--- a/spec/handling_requests_spec.rb
+++ b/spec/handling_requests_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Evervault do
     Evervault::Http::Request.new(
       timeout: 30,
       api_key: "testing",
+      app_uuid: "app_test"
     )
   end
   let(:intercept) do
@@ -50,6 +51,7 @@ qLZdvkgx0KBRnP/JPZ55VgjZ8ipH9+SGxsZeTg9sX6nw+x/Plncz
   end
   before :each do 
     Evervault.api_key = "testing" 
+    Evervault.app_uuid = "app_test"
   end
 
   describe "expired_cert" do

--- a/spec/handling_requests_spec.rb
+++ b/spec/handling_requests_spec.rb
@@ -22,7 +22,6 @@ RSpec.describe Evervault do
     Evervault::Http::RequestHandler.new(
       request: request,
       base_url: "https://api.evervault.com/", 
-      cage_run_url: "https://cage.run/", 
       cert: intercept
     ) 
   end
@@ -50,7 +49,7 @@ qLZdvkgx0KBRnP/JPZ55VgjZ8ipH9+SGxsZeTg9sX6nw+x/Plncz
 -----END CERTIFICATE-----"
   end
   before :each do 
-    Evervault.app_uuid = "app_test"
+    Evervault.app_id= "app_test"
     Evervault.api_key = "testing" 
   end
 
@@ -121,7 +120,7 @@ qLZdvkgx0KBRnP/JPZ55VgjZ8ipH9+SGxsZeTg9sX6nw+x/Plncz
            }).
          to_return(status: 200, body: "{}", headers: {})
       expect(intercept).to receive(:setup)
-      request_handler.delete("cages", {})
+      request_handler.delete("cages")
     end
   end
 end

--- a/spec/handling_requests_spec.rb
+++ b/spec/handling_requests_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe Evervault do
   let(:request) do
     Evervault::Http::Request.new(
       timeout: 30,
-      api_key: "testing",
-      app_uuid: "app_test"
+      app_uuid: "app_test",
+      api_key: "testing"
     )
   end
   let(:intercept) do
@@ -50,8 +50,8 @@ qLZdvkgx0KBRnP/JPZ55VgjZ8ipH9+SGxsZeTg9sX6nw+x/Plncz
 -----END CERTIFICATE-----"
   end
   before :each do 
-    Evervault.api_key = "testing" 
     Evervault.app_uuid = "app_test"
+    Evervault.api_key = "testing" 
   end
 
   describe "expired_cert" do

--- a/spec/relay_outbound_config_spec.rb
+++ b/spec/relay_outbound_config_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Evervault do
     Evervault::Http::Request.new(
       timeout: 30,
       api_key: "testing",
+      app_uuid: "app_test"
     )
   end
 

--- a/spec/relay_outbound_config_spec.rb
+++ b/spec/relay_outbound_config_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Evervault do
   let(:request) do
     Evervault::Http::Request.new(
       timeout: 30,
-      api_key: "testing",
-      app_uuid: "app_test"
+      app_uuid: "app_test",
+      api_key: "testing"
     )
   end
 

--- a/spec/validation_utils_spec.rb
+++ b/spec/validation_utils_spec.rb
@@ -1,0 +1,33 @@
+require_relative "spec_helper"
+
+RSpec.describe Evervault do
+  describe "ValidationUtils" do
+    describe "validate_app_uuid_and_api_key" do
+      it "should raise an error if the app_uuid is nil" do
+        expect {
+          Evervault::Utils::ValidationUtils.validate_app_uuid_and_api_key(nil, "test")
+        }.to raise_error(Evervault::Errors::AuthenticationError)
+      end
+
+      it "should raise an error if the api_key is nil" do
+        expect {
+          Evervault::Utils::ValidationUtils.validate_app_uuid_and_api_key("test", nil)
+        }.to raise_error(Evervault::Errors::AuthenticationError)
+      end
+
+      it "should raise an error if the api_key does not belong to the app" do
+        expect {
+          Evervault::Utils::ValidationUtils.validate_app_uuid_and_api_key('app_28807f2a6bb2', 'ev:key:1:random:sZ4zvj:9iZ95W')
+        }.to raise_error(Evervault::Errors::AuthenticationError)
+      end
+
+      it "should not raise an error if the App ID and the scoped API key are valid" do
+        Evervault::Utils::ValidationUtils.validate_app_uuid_and_api_key('app_28807f2a6bb1', 'ev:key:1:random:sZ4zvj:9iZ95W')
+      end
+
+      it "should not raise an error if the App ID and the legacy API key are valid" do
+        Evervault::Utils::ValidationUtils.validate_app_uuid_and_api_key('app_28807f2a6bb1', 'some_api_key_material')
+      end
+    end
+  end
+end


### PR DESCRIPTION
BREAKING CHANGE: The UUID of the App is now required when initialising the SDK

# Why
- Add `Evervault.decrypt()` function
- Require `app_uuid` when initialising the SDK to allow for authentication.

# How
- Require `app_uuid`
- Add `Evervault.decrypt()` function

BREAKING CHANGE: The UUID of the App is now required when initialising the SDK