### PR TITLE
Align matching rules with relay

### DIFF
--- a/spec/intercepting_request_spec.rb
+++ b/spec/intercepting_request_spec.rb
@@ -19,6 +19,21 @@ RSpec.describe Evervault do
         NetHTTPOverride.add_get_decryption_domains_func(lambda { ["example.com"] })
         expect(NetHTTPOverride.should_decrypt("otherexample.com")).to eq(false)
       end
+
+      it "returns true if the domain is given in a domain and subdomain matcher" do
+        NetHTTPOverride.add_get_decryption_domains_func(lambda { ["*example.com"] })
+        expect(NetHTTPOverride.should_decrypt("example.com")).to eq(true)
+      end
+
+      it "returns true if a subdomain is given in a domain and subdomain matcher" do
+        NetHTTPOverride.add_get_decryption_domains_func(lambda { ["*example.com"] })
+        expect(NetHTTPOverride.should_decrypt("test.example.com")).to eq(true)
+      end
+      
+      it "returns false if a malicious domain that has the domain and subdomain matcher as a suffix" do
+        NetHTTPOverride.add_get_decryption_domains_func(lambda { ["*example.com"] })
+        expect(NetHTTPOverride.should_decrypt("malicious_example.com")).to eq(false)
+      end
     end
   end
 end


### PR DESCRIPTION
# Why

Domain matching logic was being done case sensitively and in a manner different to how it is described in the UI.

# How

Generate regexes that match as described in the UI, ignoring case.