### PR TITLE
Add e2e tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,19 @@
+name: evervault-e2e-tests
+on: [push]
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu, macos]
+        ruby: [2.6, 2.7, 3.1, truffleruby]
+    runs-on: ${{ matrix.os }}-latest
+    continue-on-error: ${{ endsWith(matrix.ruby, 'head') || matrix.ruby == 'debug' }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+      - run: bundle install
+      - run: bundle exec rake e2e_tests

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,3 +17,8 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
       - run: bundle install
       - run: bundle exec rake e2e_tests
+        env:
+          EVERVAULT_APP_UUID: ${{ secrets.EVERVAULT_APP_UUID }}
+          EVERVAULT_API_KEY: ${{ secrets.EVERVAULT_API_KEY }}
+          EVERVAULT_FUNCTION_NAME: ${{ secrets.EVERVAULT_FUNCTION_NAME }}
+          EVERVAULT_SYNTHETIC_ENDPOINT_URL: ${{ secrets.EVERVAULT_SYNTHETIC_ENDPOINT_URL }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -16,4 +16,4 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
       - run: bundle install
-      - run: bundle exec rake
+      - run: bundle exec rake unit_tests

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ Gemfile.lock
 
 # rspec failure tracking
 .rspec_status
+.rspec_status_e2e
 
 # rbenv
 .ruby_version

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,21 @@
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 
-RSpec::Core::RakeTask.new(:spec)
-
-task :default => :spec
+task :e2e_tests do
+    RSpec::Core::RakeTask.new(:spec) do |t|
+      t.pattern = 'spec/e2e/*_spec.rb'
+    end
+    Rake::Task["spec"].execute
+end
+  
+task :unit_tests do
+    RSpec::Core::RakeTask.new(:spec) do |t|
+      t.pattern = 'spec/*_spec.rb'
+    end
+    Rake::Task["spec"].execute
+end
+  
+task :default do
+    RSpec::Core::RakeTask.new(:spec)
+    Rake::Task["spec"].execute
+end

--- a/spec/e2e/encrypt_e2e_spec.rb
+++ b/spec/e2e/encrypt_e2e_spec.rb
@@ -1,52 +1,52 @@
 require_relative "spec_helper"
 
 RSpec.describe Evervault do
-    describe "E2E Encrypt Tests" do
-      app_uuid = ENV["EVERVAULT_APP_UUID"]
-      api_key = ENV["EVERVAULT_API_KEY"]
-      Evervault.app_id = app_uuid
-      Evervault.api_key = api_key
-      
-      it "should encrypt a string" do
-        payload = "hello world"
-        encryptResult = Evervault.encrypt(payload)
-        decryptResult = Evervault.decrypt(encryptResult)
-        expect(decryptResult).to eq(payload)
-      end
+  describe "E2E Encrypt Tests" do
+    app_uuid = ENV["EVERVAULT_APP_UUID"]
+    api_key = ENV["EVERVAULT_API_KEY"]
+    Evervault.app_id = app_uuid
+    Evervault.api_key = api_key
+    
+    it "should encrypt a string" do
+      payload = "hello world"
+      encryptResult = Evervault.encrypt(payload)
+      decryptResult = Evervault.decrypt(encryptResult)
+      expect(decryptResult).to eq(payload)
+    end
 
-      it "should encrypt an integer" do
-        payload = 1
-        encryptResult = Evervault.encrypt(payload)
-        decryptResult = Evervault.decrypt(encryptResult)
-        expect(decryptResult).to eq(payload)
-      end
+    it "should encrypt an integer" do
+      payload = 1
+      encryptResult = Evervault.encrypt(payload)
+      decryptResult = Evervault.decrypt(encryptResult)
+      expect(decryptResult).to eq(payload)
+    end
 
-      it "should encrypt a float" do
-        payload = 1.0
-        encryptResult = Evervault.encrypt(payload)
-        decryptResult = Evervault.decrypt(encryptResult)
-        expect(decryptResult).to eq(payload)
-      end
+    it "should encrypt a float" do
+      payload = 1.0
+      encryptResult = Evervault.encrypt(payload)
+      decryptResult = Evervault.decrypt(encryptResult)
+      expect(decryptResult).to eq(payload)
+    end
 
-      it "should encrypt a true bool" do
-        payload = true
-        encryptResult = Evervault.encrypt(payload)
-        decryptResult = Evervault.decrypt(encryptResult)
-        expect(decryptResult).to eq(payload)
-      end
+    it "should encrypt a true bool" do
+      payload = true
+      encryptResult = Evervault.encrypt(payload)
+      decryptResult = Evervault.decrypt(encryptResult)
+      expect(decryptResult).to eq(payload)
+    end
 
-      it "should encrypt a false bool" do
-        payload = false
-        encryptResult = Evervault.encrypt(payload)
-        decryptResult = Evervault.decrypt(encryptResult)
-        expect(decryptResult).to eq(payload)
-      end
+    it "should encrypt a false bool" do
+      payload = false
+      encryptResult = Evervault.encrypt(payload)
+      decryptResult = Evervault.decrypt(encryptResult)
+      expect(decryptResult).to eq(payload)
+    end
 
-      it "should encrypt a hash" do
-        payload = {"hello" => "world"}
-        encryptResult = Evervault.encrypt(payload)
-        decryptResult = Evervault.decrypt(encryptResult)
-        expect(decryptResult).to eq(payload)
-      end
+    it "should encrypt a hash" do
+      payload = {"hello" => "world"}
+      encryptResult = Evervault.encrypt(payload)
+      decryptResult = Evervault.decrypt(encryptResult)
+      expect(decryptResult).to eq(payload)
     end
   end
+end

--- a/spec/e2e/encrypt_e2e_spec.rb
+++ b/spec/e2e/encrypt_e2e_spec.rb
@@ -1,0 +1,52 @@
+require_relative "spec_helper"
+
+RSpec.describe Evervault do
+    describe "E2E Encrypt Tests" do
+      app_uuid = ENV["EVERVAULT_APP_UUID"]
+      api_key = ENV["EVERVAULT_API_KEY"]
+      Evervault.app_id = app_uuid
+      Evervault.api_key = api_key
+      
+      it "should encrypt a string" do
+        payload = "hello world"
+        encryptResult = Evervault.encrypt(payload)
+        decryptResult = Evervault.decrypt(encryptResult)
+        expect(decryptResult).to eq(payload)
+      end
+
+      it "should encrypt an integer" do
+        payload = 1
+        encryptResult = Evervault.encrypt(payload)
+        decryptResult = Evervault.decrypt(encryptResult)
+        expect(decryptResult).to eq(payload)
+      end
+
+      it "should encrypt a float" do
+        payload = 1.0
+        encryptResult = Evervault.encrypt(payload)
+        decryptResult = Evervault.decrypt(encryptResult)
+        expect(decryptResult).to eq(payload)
+      end
+
+      it "should encrypt a true bool" do
+        payload = true
+        encryptResult = Evervault.encrypt(payload)
+        decryptResult = Evervault.decrypt(encryptResult)
+        expect(decryptResult).to eq(payload)
+      end
+
+      it "should encrypt a false bool" do
+        payload = false
+        encryptResult = Evervault.encrypt(payload)
+        decryptResult = Evervault.decrypt(encryptResult)
+        expect(decryptResult).to eq(payload)
+      end
+
+      it "should encrypt a hash" do
+        payload = {"hello" => "world"}
+        encryptResult = Evervault.encrypt(payload)
+        decryptResult = Evervault.decrypt(encryptResult)
+        expect(decryptResult).to eq(payload)
+      end
+    end
+  end

--- a/spec/e2e/function_e2e_spec.rb
+++ b/spec/e2e/function_e2e_spec.rb
@@ -1,0 +1,52 @@
+require 'faraday'
+require 'json'
+require_relative "spec_helper"
+
+RSpec.describe Evervault do
+    describe "E2E Function Tests" do
+      app_uuid = ENV["EVERVAULT_APP_UUID"]
+      api_key = ENV["EVERVAULT_API_KEY"]
+      function_name = ENV["EVERVAULT_FUNCTION_NAME"]
+      Evervault.app_id = app_uuid
+      Evervault.api_key = api_key
+      
+      it "should run a function" do
+        payload = {"name" => "John Doe", "age" => 42, "isAlive" => true}
+        encryptResult = Evervault.encrypt(payload)
+        function_run_result = Evervault.run(function_name, payload, {"async" => false})
+        expect(function_run_result["result"]["decrypted"]).to eq(payload)
+      end
+
+      it "should run a function async" do
+        payload = {"name" => "John Doe", "age" => 42, "isAlive" => true}
+        options = {async: true}
+
+        encrypt_result = Evervault.encrypt(payload)
+
+        function_run_result = Evervault.run(function_name, encrypt_result, options)
+        expect(function_run_result).to eq(nil)
+      end
+
+      it "should create a run token" do
+        payload = {"name" => "John Doe", "age" => 42, "isAlive" => true}
+        encrypt_result = Evervault.encrypt(payload)
+
+        run_token = Evervault.create_run_token(function_name, encrypt_result)
+
+        function_run_result = run_function_with_token(run_token["token"], function_name, encrypt_result)
+        expect(function_run_result["result"]["decrypted"]).to eq(payload)
+      end
+    end
+
+    private def run_function_with_token(token, function_name, payload)
+        url = "https://run.evervault.com"
+        conn = Faraday.new
+        res = conn.post do |req|
+            req.url "#{url}/#{function_name}"
+            req.headers['Content-Type'] = 'application/json'
+            req.headers['Authorization'] = "Bearer #{token}"
+            req.body = payload.to_json
+        end
+        return JSON.parse res.body
+    end
+end

--- a/spec/e2e/outbound_relay_e2e_spec.rb
+++ b/spec/e2e/outbound_relay_e2e_spec.rb
@@ -1,0 +1,32 @@
+require_relative "spec_helper"
+
+RSpec.describe Evervault do
+  describe "E2E Function Tests" do
+    app_uuid = ENV["EVERVAULT_APP_UUID"]
+    api_key = ENV["EVERVAULT_API_KEY"]
+    synthetic_endpoint_url = ENV["EVERVAULT_SYNTHETIC_ENDPOINT_URL"]
+    Evervault.app_id = app_uuid
+    Evervault.api_key = api_key
+      
+    it "should enable outbound relay" do
+      Evervault.enable_outbound_relay()
+
+      payload = {"string" => "some_string", "number" => 42, "boolean" => true}
+      encryptResult = Evervault.encrypt(payload)
+
+      url = synthetic_endpoint_url
+      conn = Faraday.new
+      res = conn.post do |req|
+        req.url "#{url}/production?uuid=ruby-sdk-run&mode=outbound"
+        req.headers['Content-Type'] = 'application/json'
+        req.body = payload.to_json
+      end
+
+      body = JSON.parse res.body
+
+      expect(body["request"]["string"]).to eq(false)
+      expect(body["request"]["number"]).to eq(false)
+      expect(body["request"]["boolean"]).to eq(false)
+    end
+  end
+end

--- a/spec/e2e/spec_helper.rb
+++ b/spec/e2e/spec_helper.rb
@@ -1,0 +1,16 @@
+require "bundler/setup"
+require "evervault"
+require "rspec"
+require "pry"
+require 'webmock/rspec'
+
+RSpec.configure do |config|
+  # Enable flags like --only-failures and --next-failure
+  config.example_status_persistence_file_path = ".rspec_status_e2e"
+
+  WebMock.enable_net_connect!
+
+  config.expect_with :rspec do |c|
+    c.syntax = :expect
+  end
+end


### PR DESCRIPTION
# Why
Developing the Ruby SDK required a lot of manual testing. Automated end-to-end tests were highly needed.

# How
This PR introduces the following changes:
- Add e2e tests to validate encryption & decryption, function runs, and outbound relay proxying
- Add github workflow to automatically trigger e2e tests when pushing a change
- Split spec into unit tests and e2e tests