### PR TITLE
Removing non-transient errors in favour of generic EvervaultError

### DIFF
--- a/.changeset/flat-dolls-jog.md
+++ b/.changeset/flat-dolls-jog.md
@@ -1,0 +1,7 @@
+---
+"evervault-ruby": major
+---
+
+Simplifying errors thrown by the SDK.
+
+Previously we exposed many different error types for users to handle, but in most cases these errors were not something that could be caught and handled, but rather indicative of a larger configuration issue. This change simplifies the errors thrown by grouping them into the generic EvervaultError unless they are a transient error which can be handled programmatically.

--- a/lib/evervault/client.rb
+++ b/lib/evervault/client.rb
@@ -35,7 +35,7 @@ module Evervault
 
     def decrypt(data)
       unless data.is_a?(String) || data.is_a?(Array) || data.is_a?(Hash)
-        raise Evervault::Errors::ArgumentError.new("data is of invalid type")
+        raise Evervault::Errors::EvervaultError.new("data is of invalid type")
       end
       payload = { data: data }
       response = @request_handler.post("decrypt", payload, true, Evervault::Errors::ErrorMap)

--- a/lib/evervault/crypto/client.rb
+++ b/lib/evervault/crypto/client.rb
@@ -22,11 +22,11 @@ module Evervault
       end
 
       def encrypt(data)
-        raise Evervault::Errors::UndefinedDataError.new(
+        raise Evervault::Errors::EvervaultError.new(
           "Data is required for encryption"
         ) if data.nil? || (data.instance_of?(String) && data.empty?)
 
-        raise Evervault::Errors::UnsupportedEncryptType.new(
+        raise Evervault::Errors::EvervaultError.new(
           "Encryption is not supported for #{data.class}"
         ) if !(encryptable_data?(data) || data.instance_of?(Hash) || data.instance_of?(Array))
           
@@ -64,7 +64,7 @@ module Evervault
           encrypted_data = data.map { |value| traverse_and_encrypt(value) }
           return encrypted_data
         else
-          raise Evervault::Errors::UnsupportedEncryptType.new(
+          raise Evervault::Errors::EvervaultError.new(
             "Encryption is not supported for #{data.class}"
           )
         end

--- a/lib/evervault/errors/error_map.rb
+++ b/lib/evervault/errors/error_map.rb
@@ -8,15 +8,7 @@ module Evervault
         code = parsed_body["code"]
         detail = parsed_body["detail"]
 
-        if code == "unauthorized"
-          raise AuthenticationError.new(detail)
-        elsif code == "forbidden"
-          raise ForbiddenError.new(detail)
-        elsif code == "unprocessable-content"
-          raise DecryptionError.new(detail)
-        elsif code == "invalid-request"
-          raise BadRequestError.new(detail)
-        elsif code == "functions/request-timeout"
+        if code == "functions/request-timeout"
           raise FunctionTimeoutError.new(detail)
         elsif code == "functions/function-not-ready"
           raise FunctionNotReadyError.new(detail)

--- a/lib/evervault/errors/errors.rb
+++ b/lib/evervault/errors/errors.rb
@@ -2,36 +2,6 @@ module Evervault
   module Errors
     class EvervaultError < StandardError; end
 
-    class ArgumentError < EvervaultError; end
-
-    class HttpError < EvervaultError; end
-
-    class ResourceNotFoundError < EvervaultError; end
-
-    class AuthenticationError < EvervaultError; end
-
-    class ForbiddenError < EvervaultError; end
-
-    class ServerError < EvervaultError; end
-
-    class BadGatewayError < EvervaultError; end
-
-    class ServiceUnavailableError < EvervaultError; end
-
-    class BadRequestError < EvervaultError; end
-
-    class UndefinedDataError < EvervaultError; end
-
-    class InvalidPublicKeyError < EvervaultError; end
-
-    class UnexpectedError < EvervaultError; end
-
-    class CertDownloadError < EvervaultError; end
-
-    class UnsupportedEncryptType < EvervaultError; end
-
-    class DecryptionError < EvervaultError; end
-
     class FunctionError < EvervaultError; end
 
     class ForbiddenIPError < FunctionError; end

--- a/lib/evervault/errors/legacy_error_map.rb
+++ b/lib/evervault/errors/legacy_error_map.rb
@@ -7,25 +7,25 @@ module Evervault
         return if status_code < 400
         case status_code
         when 404
-          raise ResourceNotFoundError.new("Resource Not Found")
+          raise EvervaultError.new("Resource not found")
         when 400
-          raise BadRequestError.new("Bad request")
+          raise EvervaultError.new("Bad request")
         when 401
-          raise AuthenticationError.new("Unauthorized")
+          raise EvervaultError.new("Unauthorized")
         when 403
           if (headers.include? "x-evervault-error-code") && (headers["x-evervault-error-code"] == "forbidden-ip-error")
             raise ForbiddenIPError.new("IP is not present in Cage whitelist")
           else
-            raise AuthenticationError.new("Forbidden")
+            raise EvervaultError.new("Forbidden")
           end
         when 500
-          raise ServerError.new("Server Error")
+          raise EvervaultError.new("Server error")
         when 502
-          raise BadGatewayError.new("Bad Gateway Error")
+          raise EvervaultError.new("Bad gateway error")
         when 503
-          raise ServiceUnavailableError.new("Service Unavailable")
+          raise EvervaultError.new("Service unavailable")
         else
-          raise UnexpectedError.new(
+          raise EvervaultError.new(
                   self.message_for_unexpected_error_without_type(body)
                 )
         end

--- a/lib/evervault/http/request_intercept.rb
+++ b/lib/evervault/http/request_intercept.rb
@@ -128,7 +128,7 @@ module Evervault
         end
 
         if !ca_content || ca_content == ""
-          raise Evervault::Errors::CertDownloadError.new("Unable to install the Evervault root certificate from #{@ca_host}")
+          raise Evervault::Errors::EvervaultError.new("Unable to install the Evervault root certificate from #{@ca_host}")
         end
 
         cert = OpenSSL::X509::Certificate.new ca_content

--- a/lib/evervault/utils/validation_utils.rb
+++ b/lib/evervault/utils/validation_utils.rb
@@ -6,12 +6,12 @@ module Evervault
 
       def self.validate_app_uuid_and_api_key(app_uuid, api_key)
         if app_uuid.nil?
-          raise Evervault::Errors::AuthenticationError.new(
+          raise Evervault::Errors::EvervaultError.new(
             "No App ID provided. The App ID can be retrieved in the Evervault dashboard (App Settings)."
           )
         end
         if api_key.nil?
-          raise Evervault::Errors::AuthenticationError.new(
+          raise Evervault::Errors::EvervaultError.new(
             "The provided App ID is invalid. The App ID can be retrieved in the Evervault dashboard (App Settings)."
           )
         end
@@ -20,7 +20,7 @@ module Evervault
           app_uuid_hash = Digest::SHA512.base64digest(app_uuid)[0, 6]
           app_uuid_hash_from_api_key = api_key.split(':')[4]
           if app_uuid_hash != app_uuid_hash_from_api_key
-            raise Evervault::Errors::AuthenticationError.new(
+            raise Evervault::Errors::EvervaultError.new(
               "The API key is not valid for app #{app_uuid}. Make sure to use an API key belonging to the app #{app_uuid}."
             )
           end

--- a/spec/evervault_spec.rb
+++ b/spec/evervault_spec.rb
@@ -135,8 +135,8 @@ Gu2q1tR9TzpXYZ+Yv1/YUApnryI8Dbd2azpYW4obHvGOFS1bxNQ3waqmx51ig45S
       end
       test_instance = MyTestClass.new()
       list = ["a", 1, test_instance]
-      expect { Evervault.encrypt(test_instance) }.to raise_error(Evervault::Errors::UnsupportedEncryptType)
-      expect { Evervault.encrypt(list) }.to raise_error(Evervault::Errors::UnsupportedEncryptType)
+      expect { Evervault.encrypt(test_instance) }.to raise_error(Evervault::Errors::EvervaultError)
+      expect { Evervault.encrypt(list) }.to raise_error(Evervault::Errors::EvervaultError)
     end
 
   end
@@ -213,7 +213,7 @@ Gu2q1tR9TzpXYZ+Yv1/YUApnryI8Dbd2azpYW4obHvGOFS1bxNQ3waqmx51ig45S
       } }
       let(:status) { 400 }
       it "makes a post request to the API and maps the error" do
-        expect { Evervault.run("testing-function", { name: "testing" }) }.to raise_error(Evervault::Errors::BadRequestError)
+        expect { Evervault.run("testing-function", { name: "testing" }) }.to raise_error(Evervault::Errors::EvervaultError)
         assert_requested(:post, "https://api.evervault.com/functions/testing-function/runs", body: { payload: { name: "testing" } }, times: 1)
       end
     end
@@ -262,7 +262,7 @@ Gu2q1tR9TzpXYZ+Yv1/YUApnryI8Dbd2azpYW4obHvGOFS1bxNQ3waqmx51ig45S
       } }
       let(:status) { 400 }
       it "makes a post request to the API and maps the error" do
-        expect { Evervault.create_client_side_decrypt_token("test", Time.parse('2023-08-09 16:00:54 +0000')) }.to raise_error(Evervault::Errors::BadRequestError)
+        expect { Evervault.create_client_side_decrypt_token("test", Time.parse('2023-08-09 16:00:54 +0000')) }.to raise_error(Evervault::Errors::EvervaultError)
         assert_requested(:post, "https://api.evervault.com/client-side-tokens", body: { action: 'api:decrypt', payload: 'test', expiry: 1691596854000 }, times: 1)
       end
     end
@@ -302,7 +302,7 @@ Gu2q1tR9TzpXYZ+Yv1/YUApnryI8Dbd2azpYW4obHvGOFS1bxNQ3waqmx51ig45S
       let(:status) { 400 }
 
       it "makes a post request to the API and maps the error" do
-        expect { Evervault.create_run_token("testing-function", { name: "testing" }) }.to raise_error(Evervault::Errors::BadRequestError)
+        expect { Evervault.create_run_token("testing-function", { name: "testing" }) }.to raise_error(Evervault::Errors::EvervaultError)
         assert_requested(:post, "https://api.evervault.com/v2/functions/testing-function/run-token", body: { name: "testing" }, times: 1)
       end
     end

--- a/spec/handling_cert_spec.rb
+++ b/spec/handling_cert_spec.rb
@@ -134,7 +134,7 @@ qLZdvkgx0KBRnP/JPZ55VgjZ8ipH9+SGxsZeTg9sX6nw+x/Plncz
             "User-Agent"=>"evervault-ruby/#{Evervault::VERSION}"
           }).
         to_return({ status: 200, body: ""})
-      expect { intercept.setup() }.to raise_error(Evervault::Errors::CertDownloadError)
+      expect { intercept.setup() }.to raise_error(Evervault::Errors::EvervaultError)
       expect(intercept.is_certificate_expired()).to be false
     end
   end

--- a/spec/validation_utils_spec.rb
+++ b/spec/validation_utils_spec.rb
@@ -6,19 +6,19 @@ RSpec.describe Evervault do
       it "should raise an error if the app_uuid is nil" do
         expect {
           Evervault::Utils::ValidationUtils.validate_app_uuid_and_api_key(nil, "test")
-        }.to raise_error(Evervault::Errors::AuthenticationError)
+        }.to raise_error(Evervault::Errors::EvervaultError)
       end
 
       it "should raise an error if the api_key is nil" do
         expect {
           Evervault::Utils::ValidationUtils.validate_app_uuid_and_api_key("test", nil)
-        }.to raise_error(Evervault::Errors::AuthenticationError)
+        }.to raise_error(Evervault::Errors::EvervaultError)
       end
 
       it "should raise an error if the api_key does not belong to the app" do
         expect {
           Evervault::Utils::ValidationUtils.validate_app_uuid_and_api_key('app_28807f2a6bb2', 'ev:key:1:random:sZ4zvj:9iZ95W')
-        }.to raise_error(Evervault::Errors::AuthenticationError)
+        }.to raise_error(Evervault::Errors::EvervaultError)
       end
 
       it "should not raise an error if the App ID and the scoped API key are valid" do


### PR DESCRIPTION
# Why
We have some errors which don't serve our users any better than a generic EvervaultError would. We should remove these and only raise specific errors when a specific action would be taken by the user in this scenario (eg. retrying)

# How
Removed non-transient errors