### PR TITLE
Add Faraday as a gem dependency

### DIFF
--- a/.changeset/sweet-lions-warn.md
+++ b/.changeset/sweet-lions-warn.md
@@ -1,0 +1,5 @@
+---
+"evervault-ruby": patch
+---
+
+Add Faraday as a gem dependency

--- a/evervault.gemspec
+++ b/evervault.gemspec
@@ -13,6 +13,8 @@ Gem::Specification.new do |spec|
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/evervault/evervault-ruby"
 
+  spec.add_dependency "faraday", [">= 2.0", "< 3.0"]
+
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
   spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do


### PR DESCRIPTION
# Why

We use Faraday inside of the gem but it's not listed as a dependency. This will lead to an error if the user doesn't have Faraday as a dependency in their project.

Closes #20 