### PR TITLE
Increasing clarity in changeset

### DIFF
--- a/.changeset/flat-dolls-jog.md
+++ b/.changeset/flat-dolls-jog.md
@@ -4,4 +4,4 @@
 
 Simplifying errors thrown by the SDK.
 
-Previously we exposed many different error types for users to handle, but in most cases these errors were not something that could be caught and handled, but rather indicative of a larger configuration issue. This change simplifies the errors thrown by grouping them into the generic EvervaultError unless they are a transient error which can be handled programmatically.
+Previously we exposed many different error types for users to handle, but in most cases these errors were not something that could be caught and handled, but were rather indicative of a larger configuration issue. This change simplifies the errors thrown by returning an EvervaultError with accompanying error message by default, unless they are a transient error which can be handled programmatically, in which case a specific error is returned.

--- a/.changeset/lovely-oranges-reflect.md
+++ b/.changeset/lovely-oranges-reflect.md
@@ -2,4 +2,6 @@
 "evervault-ruby": major
 ---
 
-Migrated Function run requests to new API. Added more comprehensive error handling for Function runs.
+Migrated Function run requests to new API.
+
+We have released a new API for Function run requests which is more robust, more extensible, and which provides more useful error messages when Function runs fail. In addition, we have removed async Function run requests and specifying the version of the Function to run. For more details check out https://docs.evervault.com/sdks/ruby#run()


### PR DESCRIPTION
# Why
The original changeset messages were not clear enough for user consumption

# How
Updated changeset messages