### PR TITLE
Drop support for Ruby 2.6 and 2.7

### DIFF
--- a/.changeset/giant-crabs-think.md
+++ b/.changeset/giant-crabs-think.md
@@ -1,0 +1,6 @@
+---
+"evervault-ruby": major
+---
+
+We have dropped support for Ruby 2.6 and 2.7 as they are now both in end of life status.
+See more: https://www.ruby-lang.org/en/downloads/branches

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,8 +6,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu, macos]
-        ruby: [2.6, 2.7, 3.1, truffleruby]
+        os: [ubuntu]
+        ruby: [3.0, 3.1, 3.2]
     runs-on: ${{ matrix.os }}-latest
     continue-on-error: ${{ endsWith(matrix.ruby, 'head') || matrix.ruby == 'debug' }}
     steps:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -6,8 +6,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu, macos]
-        ruby: [2.6, 2.7, 3.1, truffleruby]
+        os: [ubuntu]
+        ruby: [3.0, 3.1, 3.2]
     runs-on: ${{ matrix.os }}-latest
     continue-on-error: ${{ endsWith(matrix.ruby, 'head') || matrix.ruby == 'debug' }}
     steps:

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2020 Jonny
+Copyright (c) 2020 Evervault
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/evervault.gemspec
+++ b/evervault.gemspec
@@ -3,13 +3,12 @@ require_relative 'lib/evervault/version'
 Gem::Specification.new do |spec|
   spec.name          = "evervault"
   spec.version       = Evervault::VERSION
-  spec.authors       = ["Jonny O'Mahony"]
-  spec.email         = ["jonny@evervault.com"]
-
+  spec.authors       = ["Evervault"]
+  spec.email         = "support@evervault.com"
   spec.summary       = %q{Ruby SDK to run Evervault}
   spec.homepage      = "https://evervault.com"
   spec.license       = "MIT"
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.3.0")
+  spec.required_ruby_version = ">= 3.0.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/evervault/evervault-ruby"


### PR DESCRIPTION
# Why

Ruby 2.6 and 2.7 are both in end of life status.

This PR also simplifies are test matrix. We are currently running tests on 2.6, 2.7, 3.1 and truffleruby on both Ubuntu and macOS. This is likely overkill at the moment and can be reduced to just current active ruby versions on Ubuntu.