### PR TITLE
Improve configuration API's

### DIFF
--- a/.changeset/little-queens-attend.md
+++ b/.changeset/little-queens-attend.md
@@ -1,0 +1,14 @@
+---
+"evervault-ruby": patch
+---
+
+Improved API for configuring the Evervault::Client.
+
+Previously there was no way to set the curve used for encryption. This can now
+be configured via the .configure method.
+
+```
+Evervault.configure do |config|
+  config.curve = "secp256k1"
+end
+```

--- a/lib/evervault.rb
+++ b/lib/evervault.rb
@@ -3,6 +3,7 @@
 require 'time'
 require_relative 'evervault/version'
 require_relative 'evervault/client'
+require_relative 'evervault/config'
 require_relative 'evervault/errors/errors'
 require_relative 'evervault/utils/validation_utils'
 
@@ -33,6 +34,10 @@ module Evervault
     def create_client_side_decrypt_token(data, expiry = nil)
       expiry = (expiry.to_f * 1000).to_i unless expiry.nil?
       client.create_token('api:decrypt', data, expiry)
+    end
+
+    def configure(...)
+      client.configure(...)
     end
 
     private

--- a/lib/evervault.rb
+++ b/lib/evervault.rb
@@ -1,44 +1,47 @@
-require "time"
-require_relative "evervault/version"
-require_relative "evervault/client"
-require_relative "evervault/errors/errors"
-require_relative "evervault/utils/validation_utils"
+# frozen_string_literal: true
+
+require 'time'
+require_relative 'evervault/version'
+require_relative 'evervault/client'
+require_relative 'evervault/errors/errors'
+require_relative 'evervault/utils/validation_utils'
 
 module Evervault
   class << self
-    attr_accessor :app_id
-    attr_accessor :api_key
+    attr_accessor :app_id, :api_key
 
-    def encrypt(data, role = nil)
-      client.encrypt(data, role)
+    def encrypt(...)
+      client.encrypt(...)
     end
 
-    def decrypt(data)
-      client.decrypt(data)
+    def decrypt(...)
+      client.decrypt(...)
     end
 
-    def run(function_name, encrypted_data)
-      client.run(function_name, encrypted_data)
+    def run(...)
+      client.run(...)
     end
 
-    def enable_outbound_relay(decryption_domains = nil)
-      client.enable_outbound_relay(decryption_domains)
+    def enable_outbound_relay(...)
+      client.enable_outbound_relay(...)
     end
 
-    def create_run_token(function_name, data = {})
-      client.create_run_token(function_name, data)
+    def create_run_token(...)
+      client.create_run_token(...)
     end
 
     def create_client_side_decrypt_token(data, expiry = nil)
-      if expiry != nil
-        expiry = (expiry.to_f * 1000).to_i
-      end
-      client.create_token("api:decrypt", data, expiry)
+      expiry = (expiry.to_f * 1000).to_i unless expiry.nil?
+      client.create_token('api:decrypt', data, expiry)
     end
 
-    private def client
-      Evervault::Utils::ValidationUtils.validate_app_uuid_and_api_key(app_id, api_key)
-      @client ||= Evervault::Client.new(app_uuid: app_id, api_key: api_key)
+    private
+
+    def client
+      @client ||= begin
+        Evervault::Utils::ValidationUtils.validate_app_uuid_and_api_key(app_id, api_key)
+        Evervault::Client.new(app_uuid: app_id, api_key: api_key)
+      end
     end
   end
 end

--- a/lib/evervault/client.rb
+++ b/lib/evervault/client.rb
@@ -1,9 +1,9 @@
-require_relative "http/request"
-require_relative "http/request_handler"
-require_relative "http/request_intercept"
-require_relative "http/relay_outbound_config"
-require_relative "threading/repeated_timer"
-require_relative "crypto/client"
+require_relative 'http/request'
+require_relative 'http/request_handler'
+require_relative 'http/request_intercept'
+require_relative 'http/relay_outbound_config'
+require_relative 'threading/repeated_timer'
+require_relative 'crypto/client'
 
 module Evervault
   class Client
@@ -12,9 +12,9 @@ module Evervault
     def initialize(
       app_uuid:,
       api_key:,
-      base_url: "https://api.evervault.com/",
-      relay_url: "https://relay.evervault.com:8443",
-      ca_host: "https://ca.evervault.com",
+      base_url: 'https://api.evervault.com/',
+      relay_url: 'https://relay.evervault.com:8443',
+      ca_host: 'https://ca.evervault.com',
       request_timeout: 30,
       curve: 'prime256v1'
     )
@@ -27,7 +27,7 @@ module Evervault
           request: @request, base_url: base_url, cert: @intercept
         )
       @crypto_client = Evervault::Crypto::Client.new(request_handler: @request_handler, curve: curve)
-      @intercept.setup()
+      @intercept.setup
     end
 
     def encrypt(data, role = nil)
@@ -36,27 +36,26 @@ module Evervault
 
     def decrypt(data)
       unless data.is_a?(String) || data.is_a?(Array) || data.is_a?(Hash)
-        raise Evervault::Errors::EvervaultError.new("data is of invalid type")
+        raise Evervault::Errors::EvervaultError, 'data is of invalid type'
       end
+
       payload = { data: data }
-      response = @request_handler.post("decrypt", payload, true, Evervault::Errors::ErrorMap)
-      response["data"]
+      response = @request_handler.post('decrypt', payload, true, Evervault::Errors::ErrorMap)
+      response['data']
     end
 
     def create_token(action, data, expiry = nil)
       payload = { payload: data, expiry: expiry, action: action }
-      @request_handler.post("client-side-tokens", payload, true, Evervault::Errors::ErrorMap)
+      @request_handler.post('client-side-tokens', payload, true, Evervault::Errors::ErrorMap)
     end
 
     def run(function_name, payload)
       payload = { payload: payload }
       res = @request_handler.post("functions/#{function_name}/runs", payload, true, Evervault::Errors::ErrorMap)
-      
-      if res["status"] == "success"
-        return res
-      else
-        return Evervault::Errors::ErrorMap.raise_function_error_on_failure(res)
-      end
+
+      return res if res['status'] == 'success'
+
+      Evervault::Errors::ErrorMap.raise_function_error_on_failure(res)
     end
 
     def create_run_token(function_name, data = {})

--- a/lib/evervault/client.rb
+++ b/lib/evervault/client.rb
@@ -1,33 +1,21 @@
-require_relative "http/request"
-require_relative "http/request_handler"
-require_relative "http/request_intercept"
-require_relative "http/relay_outbound_config"
-require_relative "threading/repeated_timer"
-require_relative "crypto/client"
+# frozen_string_literal: true
+
+require_relative 'http/request'
+require_relative 'http/request_handler'
+require_relative 'http/request_intercept'
+require_relative 'http/relay_outbound_config'
+require_relative 'threading/repeated_timer'
+require_relative 'crypto/client'
 
 module Evervault
   class Client
-    attr_reader :crypto_client
+    attr_accessor :config
 
-    def initialize(
-      app_uuid:,
-      api_key:,
-      base_url: "https://api.evervault.com/",
-      relay_url: "https://relay.evervault.com:8443",
-      ca_host: "https://ca.evervault.com",
-      request_timeout: 30,
-      curve: 'prime256v1'
-    )
-      @request = Evervault::Http::Request.new(timeout: request_timeout, app_uuid: app_uuid, api_key: api_key)
-      @intercept = Evervault::Http::RequestIntercept.new(
-        request: @request, ca_host: ca_host, api_key: api_key, base_url: base_url, relay_url: relay_url
-      )
-      @request_handler =
-        Evervault::Http::RequestHandler.new(
-          request: @request, base_url: base_url, cert: @intercept
-        )
-      @crypto_client = Evervault::Crypto::Client.new(request_handler: @request_handler, curve: curve)
-      @intercept.setup()
+    def initialize(app_uuid:, api_key:, **options, &block)
+      @config = Evervault::Config.new(app_id: app_uuid, api_key: api_key)
+      configure_via_options(**options) if options.any?
+      intercept.setup
+      configure(&block) if block_given?
     end
 
     def encrypt(data, role = nil)
@@ -36,38 +24,67 @@ module Evervault
 
     def decrypt(data)
       unless data.is_a?(String) || data.is_a?(Array) || data.is_a?(Hash)
-        raise Evervault::Errors::EvervaultError.new("data is of invalid type")
+        raise Evervault::Errors::EvervaultError, 'data is of invalid type'
       end
+
       payload = { data: data }
-      response = @request_handler.post("decrypt", payload, true, Evervault::Errors::ErrorMap)
-      response["data"]
+      response = request_handler.post('decrypt', payload, true, Evervault::Errors::ErrorMap)
+      response['data']
     end
 
     def create_token(action, data, expiry = nil)
       payload = { payload: data, expiry: expiry, action: action }
-      @request_handler.post("client-side-tokens", payload, true, Evervault::Errors::ErrorMap)
+      request_handler.post('client-side-tokens', payload, true, Evervault::Errors::ErrorMap)
     end
 
     def run(function_name, payload)
       payload = { payload: payload }
-      res = @request_handler.post("functions/#{function_name}/runs", payload, true, Evervault::Errors::ErrorMap)
-      
-      if res["status"] == "success"
-        return res
-      else
-        return Evervault::Errors::ErrorMap.raise_function_error_on_failure(res)
-      end
+      res = request_handler.post("functions/#{function_name}/runs", payload, true, Evervault::Errors::ErrorMap)
+
+      return res if res['status'] == 'success'
+
+      Evervault::Errors::ErrorMap.raise_function_error_on_failure(res)
     end
 
     def create_run_token(function_name, data = {})
-      @request_handler.post("v2/functions/#{function_name}/run-token", data)
+      request_handler.post("v2/functions/#{function_name}/run-token", data)
     end
 
     def enable_outbound_relay(decryption_domains = nil)
       if decryption_domains.nil?
-        @intercept.setup_outbound_relay_config
+        intercept.setup_outbound_relay_config
       else
-        @intercept.setup_decryption_domains(decryption_domains)
+        intercept.setup_decryption_domains(decryption_domains)
+      end
+    end
+
+    def configure
+      yield(config)
+    end
+
+    private
+
+    def request
+      @request || Evervault::Http::Request.new(config: config)
+    end
+
+    def intercept
+      @intercept || Evervault::Http::RequestIntercept.new(request: request, config: config)
+    end
+
+    def request_handler
+      @request_handler || Evervault::Http::RequestHandler.new(request: request, config: config, cert: intercept)
+    end
+
+    def crypto_client
+      @crypto_client || Evervault::Crypto::Client.new(request_handler: request_handler, config: config)
+    end
+
+    def configure_via_options(**options)
+      warn '[DEPRECATION] configuration via Evervault::Client.new arguments is deprecated. Pass a block or use the `.configure` instead.'
+
+      options.each do |key, value|
+        config.send("#{key}=", value)
       end
     end
   end

--- a/lib/evervault/client.rb
+++ b/lib/evervault/client.rb
@@ -1,9 +1,9 @@
-require_relative 'http/request'
-require_relative 'http/request_handler'
-require_relative 'http/request_intercept'
-require_relative 'http/relay_outbound_config'
-require_relative 'threading/repeated_timer'
-require_relative 'crypto/client'
+require_relative "http/request"
+require_relative "http/request_handler"
+require_relative "http/request_intercept"
+require_relative "http/relay_outbound_config"
+require_relative "threading/repeated_timer"
+require_relative "crypto/client"
 
 module Evervault
   class Client
@@ -12,9 +12,9 @@ module Evervault
     def initialize(
       app_uuid:,
       api_key:,
-      base_url: 'https://api.evervault.com/',
-      relay_url: 'https://relay.evervault.com:8443',
-      ca_host: 'https://ca.evervault.com',
+      base_url: "https://api.evervault.com/",
+      relay_url: "https://relay.evervault.com:8443",
+      ca_host: "https://ca.evervault.com",
       request_timeout: 30,
       curve: 'prime256v1'
     )
@@ -27,7 +27,7 @@ module Evervault
           request: @request, base_url: base_url, cert: @intercept
         )
       @crypto_client = Evervault::Crypto::Client.new(request_handler: @request_handler, curve: curve)
-      @intercept.setup
+      @intercept.setup()
     end
 
     def encrypt(data, role = nil)
@@ -36,26 +36,27 @@ module Evervault
 
     def decrypt(data)
       unless data.is_a?(String) || data.is_a?(Array) || data.is_a?(Hash)
-        raise Evervault::Errors::EvervaultError, 'data is of invalid type'
+        raise Evervault::Errors::EvervaultError.new("data is of invalid type")
       end
-
       payload = { data: data }
-      response = @request_handler.post('decrypt', payload, true, Evervault::Errors::ErrorMap)
-      response['data']
+      response = @request_handler.post("decrypt", payload, true, Evervault::Errors::ErrorMap)
+      response["data"]
     end
 
     def create_token(action, data, expiry = nil)
       payload = { payload: data, expiry: expiry, action: action }
-      @request_handler.post('client-side-tokens', payload, true, Evervault::Errors::ErrorMap)
+      @request_handler.post("client-side-tokens", payload, true, Evervault::Errors::ErrorMap)
     end
 
     def run(function_name, payload)
       payload = { payload: payload }
       res = @request_handler.post("functions/#{function_name}/runs", payload, true, Evervault::Errors::ErrorMap)
-
-      return res if res['status'] == 'success'
-
-      Evervault::Errors::ErrorMap.raise_function_error_on_failure(res)
+      
+      if res["status"] == "success"
+        return res
+      else
+        return Evervault::Errors::ErrorMap.raise_function_error_on_failure(res)
+      end
     end
 
     def create_run_token(function_name, data = {})

--- a/lib/evervault/config.rb
+++ b/lib/evervault/config.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Evervault
+  class Config
+    attr_accessor :app_id, :api_key, :base_url, :relay_url, :ca_host, :request_timeout, :curve
+
+    def initialize(app_id:, api_key:)
+      @app_id = app_id
+      @api_key = api_key
+      @base_url = 'https://api.evervault.com/'
+      @relay_url = 'https://relay.evervault.com:8443'
+      @ca_host = 'https://ca.evervault.com'
+      @request_timeout = 30
+      @curve = 'prime256v1'
+    end
+  end
+end

--- a/lib/evervault/http/request_handler.rb
+++ b/lib/evervault/http/request_handler.rb
@@ -6,9 +6,11 @@ require_relative "../errors/error_map"
 module Evervault
   module Http
     class RequestHandler
-      def initialize(request:, base_url:, cert:)
+      attr_reader :config
+
+      def initialize(request:, config:, cert:)
         @request = request
-        @base_url = base_url
+        @config = config
         @cert = cert
       end
 
@@ -49,7 +51,7 @@ module Evervault
       end
 
       private def build_url(path)
-        return "#{@base_url}#{path}"
+        return "#{config.base_url}#{path}"
       end
     end
   end

--- a/spec/e2e/encrypt_spec.rb
+++ b/spec/e2e/encrypt_spec.rb
@@ -10,9 +10,14 @@ RSpec.describe 'Encryption' do
       let(:client) do
         Evervault::Client.new(
           app_uuid: ENV['EVERVAULT_APP_UUID'],
-          api_key: ENV['EVERVAULT_API_KEY'],
-          curve: curve
+          api_key: ENV['EVERVAULT_API_KEY']
         )
+      end
+
+      before :each do
+        client.configure do |config|
+          config.curve = curve
+        end
       end
 
       context 'when given a string' do

--- a/spec/evervault/crypto/client_spec.rb
+++ b/spec/evervault/crypto/client_spec.rb
@@ -1,34 +1,11 @@
 # frozen_string_literal: true
 
 RSpec.describe Evervault::Crypto::Client do
-  let(:request) do
-    Evervault::Http::Request.new(
-      timeout: 30,
-      app_uuid: 'app_test',
-      api_key: 'testing'
-    )
-  end
-
-  let(:intercept) do
-    Evervault::Http::RequestIntercept.new(
-      request: request,
-      ca_host: 'https://ca.evervault.com',
-      api_key: 'testing',
-      base_url: 'https://api.evervault.com/',
-      relay_url: 'https://relay.evervault.com:8443'
-    )
-  end
-
-  let(:request_handler) do
-    Evervault::Http::RequestHandler.new(
-      request: request,
-      base_url: 'https://api.evervault.com/',
-      cert: intercept
-    )
-  end
-
-  let(:curve) { 'secp256k1' }
-  let(:client) { Evervault::Crypto::Client.new(request_handler: request_handler, curve: curve) }
+  let(:config) { Evervault::Config.new(app_id: 'app_test', api_key: 'testing') }
+  let(:request) { Evervault::Http::Request.new(config: config) }
+  let(:intercept) { Evervault::Http::RequestIntercept.new(request: request, config: config) }
+  let(:request_handler) { Evervault::Http::RequestHandler.new(request: request, config: config, cert: intercept) }
+  let(:client) { Evervault::Crypto::Client.new(request_handler: request_handler, config: config) }
 
   describe '#encrypt' do
     before do

--- a/spec/evervault/handling_cert_spec.rb
+++ b/spec/evervault/handling_cert_spec.rb
@@ -1,22 +1,9 @@
 require "webmock"
 
 RSpec.describe Evervault do
-  let(:request) do
-    Evervault::Http::Request.new(
-      timeout: 30,
-      app_uuid: "app_test",
-      api_key: "testing"
-    )
-  end
-  let(:intercept) do
-    Evervault::Http::RequestIntercept.new(
-      request: request, 
-      ca_host: "https://ca.evervault.com",
-      api_key: "testing",
-      base_url: "https://api.evervault.com/",
-      relay_url: "https://relay.evervault.com:8443",
-    )
-  end
+  let(:config) { Evervault::Config.new(app_id: 'app_test', api_key: 'testing') }
+  let(:request) { Evervault::Http::Request.new(config: config) }
+  let(:intercept) { Evervault::Http::RequestIntercept.new(request: request, config: config) }
   let(:expired_cert) do
 "-----BEGIN CERTIFICATE-----
 MIIDgzCCAmugAwIBAgIUEL9SyDnNVvLXq8opJM2nrLgoFpgwDQYJKoZIhvcNAQEL

--- a/spec/evervault/handling_requests_spec.rb
+++ b/spec/evervault/handling_requests_spec.rb
@@ -1,29 +1,10 @@
 require "webmock"
 
 RSpec.describe Evervault do
-  let(:request) do
-    Evervault::Http::Request.new(
-      timeout: 30,
-      app_uuid: "app_test",
-      api_key: "testing"
-    )
-  end
-  let(:intercept) do
-    Evervault::Http::RequestIntercept.new(
-      request: request, 
-      ca_host: "https://ca.evervault.com",
-      api_key: "testing", 
-      base_url: "https://api.evervault.com/",
-      relay_url: "https://relay.evervault.com:8443",
-    )
-  end
-  let(:request_handler) do
-    Evervault::Http::RequestHandler.new(
-      request: request,
-      base_url: "https://api.evervault.com/", 
-      cert: intercept
-    ) 
-  end
+  let(:config) { Evervault::Config.new(app_id: 'app_test', api_key: 'testing') }
+  let(:request) { Evervault::Http::Request.new(config: config) }
+  let(:intercept) { Evervault::Http::RequestIntercept.new(request: request, config: config) }
+  let(:request_handler) { Evervault::Http::RequestHandler.new(request: request, config: config, cert: intercept) }
   let(:cert) do
 "-----BEGIN CERTIFICATE-----
 MIIDgzCCAmugAwIBAgIUEL9SyDnNVvLXq8opJM2nrLgoFpgwDQYJKoZIhvcNAQEL

--- a/spec/evervault/relay_outbound_config_spec.rb
+++ b/spec/evervault/relay_outbound_config_spec.rb
@@ -2,13 +2,8 @@ require "webmock"
 require 'json'
 
 RSpec.describe Evervault do
-  let(:request) do
-    Evervault::Http::Request.new(
-      timeout: 30,
-      app_uuid: "app_test",
-      api_key: "testing"
-    )
-  end
+  let(:config) { Evervault::Config.new(app_id: 'app_test', api_key: 'testing') }
+  let(:request) { Evervault::Http::Request.new(config: config) }
 
   after :each do 
     Evervault::Http::RelayOutboundConfig.disable_polling()

--- a/spec/evervault_spec.rb
+++ b/spec/evervault_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Evervault do
     it 'delegates to the evervault client' do
       client = double('client')
       allow(Evervault).to receive(:client).and_return(client)
-      expect(client).to receive(:encrypt).with('test', nil)
+      expect(client).to receive(:encrypt).with('test')
       Evervault.encrypt('test')
     end
 

--- a/spec/evervault_spec.rb
+++ b/spec/evervault_spec.rb
@@ -1,29 +1,10 @@
 # frozen_string_literal: true
 
 RSpec.describe Evervault do
-  let(:request) do
-    Evervault::Http::Request.new(
-      timeout: 30,
-      app_uuid: 'app_test',
-      api_key: 'testing'
-    )
-  end
-  let(:intercept) do
-    Evervault::Http::RequestIntercept.new(
-      request: request,
-      ca_host: 'https://ca.evervault.com',
-      api_key: 'testing',
-      base_url: 'https://api.evervault.com/',
-      relay_url: 'https://relay.evervault.com:8443'
-    )
-  end
-  let(:request_handler) do
-    Evervault::Http::RequestHandler.new(
-      request: request,
-      base_url: 'https://api.evervault.com/',
-      cert: intercept
-    )
-  end
+  let(:config) { Evervault::Config.new(app_id: 'app_test', api_key: 'testing') }
+  let(:request) { Evervault::Http::Request.new(config: config) }
+  let(:intercept) { Evervault::Http::RequestIntercept.new(request: request, config: config) }
+  let(:request_handler) { Evervault::Http::RequestHandler.new(request: request, config: config, cert: intercept) }
   let(:crypto_client) do
     Evervault::Crypto::Client.new(request_handler: request_handler, curve: 'secp256k1')
   end


### PR DESCRIPTION
# Why

Currently there is no way to configure the curve to use for encryption without using the `Evervault::Client` directly, which isn't something we document. We also pass around a lot of configuration values to different classes. Not only is this hard to read but means that it isn't possible to change configuration after `Evervault.client` has been called as all of the values will be cached inside of instance variables.

# How

The `Evervault::Client` can now be configured in two ways:

### Via block
```rb
Evervault::Client.new(app_uuid: "app", api_key: "api_key") do |config|
  config.curve = "secp256k1"
end
```

### Via configure method

An existing client instance can be configured with with `.configure` method.

```rb
client = Evervault::Client.new(app_uuid: "app", api_key: "api_key")
client.configure do |config|
  config.curve = "secp256k1"
end
```

Note: The old way of passing configuration values with arguments is still supported but will log a deprecation warning. This is to prevent this being a breaking change.
```rb
Evervault::Client.new(app_uuid: "app", api_key: "api_key", curve: "secp256k1", base_url: "https://api.evervault.io")
```

The global `Evervault` module can also be configured globally using the `.configure` method.

```rb
Evervault.configure do |config|
  config.curve = "secp256k1"
end
```

This config instance is then passed into the other classes used meaning that if it is updated, these instances will use the newer config values.