### PR TITLE
Bump actions/cache from 4 to 5 and fix CI failures

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -11,7 +11,7 @@ jobs:
         with:
           ruby-version: 3.3
       - name: Cache gems
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: vendor/bundle
           key: ${{ runner.os }}-rubocop-${{ hashFiles('**/Gemfile.lock') }}

--- a/evervault.gemspec
+++ b/evervault.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |spec|
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = 'https://github.com/evervault/evervault-ruby'
 
+  spec.add_dependency 'base64'
   spec.add_dependency 'faraday', ['>= 2.0', '< 3.0']
 
   # Specify which files should be added to the gem when it is released.

--- a/lib/evervault/crypto/client.rb
+++ b/lib/evervault/crypto/client.rb
@@ -120,10 +120,10 @@ module Evervault
         # Perform KDF
         encoded_ephemeral_key = if config.curve == 'prime256v1'
                                   @p256.encode(decompressed_key: @ephemeral_public_key
-                                    .to_bn(:uncompressed).to_s(16)).to_der
+                                                                 .to_bn(:uncompressed).to_s(16)).to_der
                                 else
                                   @koblitz.encode(decompressed_key: @ephemeral_public_key
-                                    .to_bn(:uncompressed).to_s(16)).to_der
+                                                                    .to_bn(:uncompressed).to_s(16)).to_der
                                 end
         hash_input = shared_key + [0o0, 0o0, 0o0, 0o1].pack('C*') + encoded_ephemeral_key
         hash = OpenSSL::Digest.new('SHA256')

--- a/lib/evervault/errors/legacy_error_map.rb
+++ b/lib/evervault/errors/legacy_error_map.rb
@@ -37,7 +37,7 @@ module Evervault
 
       def message_for_unexpected_error_without_type(error_details)
         if error_details.nil?
-          return(
+          return (
             'An unexpected error occurred without message or status code. Please contact Evervault support'
           )
         end


### PR DESCRIPTION
This supersedes #54 (the Dependabot `actions/cache` v4 → v5 bump) and additionally fixes the pre-existing CI failures that were blocking it from merging.

## Changes

1. **`actions/cache` v4 → v5** — the original Dependabot bump (from #54).
2. **Add `base64` as a runtime dependency** — `lib/evervault/crypto/client.rb` does `require 'base64'`, but `base64` is no longer a default gem starting in Ruby 3.4. This was causing `LoadError: cannot load such file -- base64`, failing the `test (ubuntu, 3)` job on the latest Ruby.
3. **Fix RuboCop `Layout` offenses** flagged by the `lint` workflow (`bundle exec rubocop --only Layout`):
   - `Layout/MultilineMethodCallIndentation` in `crypto/client.rb`
   - `Layout/SpaceAroundKeyword` in `errors/legacy_error_map.rb`

## Verification

- `bundle exec rake unit_tests` → 66 examples, 0 failures
- `rubocop --parallel --only Layout` → no offenses detected

https://claude.ai/code/session_011j6qsHVzw7kq3nJpmZZ4Zf

---
_Generated by [Claude Code](https://claude.ai/code/session_011j6qsHVzw7kq3nJpmZZ4Zf)_