### PR TITLE
fix(ci): use built-in GITHUB_TOKEN for Release instead of PAT

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,12 +7,14 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
-          token: ${{ secrets.GH_TOKEN }}
       - name: Get tags
         run: git fetch --tags origin
       - name: Install Node Dependencies
@@ -29,7 +31,7 @@ jobs:
           commit: 'Release new version'
           version: npm run version
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create new release
         if: steps.changesets.outputs.hasChangesets == 'false'
         run: |
@@ -37,7 +39,7 @@ jobs:
           COMMIT_TAG=$(git tag --points-at HEAD)
           if [ -n "$COMMIT_TAG" ]; then
             echo "A tag is attached to HEAD. Creating a new release..."
-            echo "${{ secrets.GH_TOKEN }}" | gh auth login --with-token
+            echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
             CHANGELOG=$(awk '
               BEGIN { recording=0; }
               /^## / {


### PR DESCRIPTION
## Problem

Every `Release` run fails at the `actions/checkout` step:

```
fatal: could not read Username for 'https://github.com': terminal prompts disabled
```

The workflow checks out with `token: ${{ secrets.GH_TOKEN }}`, and that PAT is no longer a valid credential (rotation didn't resolve it). The `run-tests`/`e2e` workflows pass on the same commits because they use the default GitHub-generated token.

## Change

Applying the review suggestion: drop the PAT and use the token GitHub generates, granting the job only the permissions it needs.

- Add a job-level `permissions` block: `contents: write` (push tags / version commits / create release) and `pull-requests: write` (changesets opens the "New Release" PR).
- Remove `token:` from checkout so it uses the default `github.token`.
- Point the changesets action env and the `gh auth login` in the release step at `${{ secrets.GITHUB_TOKEN }}`.

## Tradeoff

Commits/PRs created with the built-in `GITHUB_TOKEN` do **not** trigger downstream workflows. So the changesets "New Release" PR won't auto-run `run-tests`/`e2e` — they'll run once a human pushes to or merges that branch. This is the documented changesets reason a PAT is sometimes used; the review accepts it.

## Verification

Merging to `master` triggers `Release`; getting past checkout (where every prior run died) confirms the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)